### PR TITLE
Fjerner muligheten for å ha flere permiteringsperioder

### DIFF
--- a/src/soknad-fakta/arbeidsforhold.ts
+++ b/src/soknad-fakta/arbeidsforhold.ts
@@ -207,19 +207,14 @@ export const arbeidsforhold: MockDataSeksjon = {
               ],
             },
             {
-              id: "faktum.arbeidsforhold-permitert",
-              type: "generator",
+              id: "faktum.arbeidsforhold-permitteringsperiode",
+              type: "periode",
               requiredAnswerIds: ["faktum.arbeidsforhold-aarsak.svar.permittert"],
-              faktum: [
-                {
-                  id: "faktum.arbeidsforhold-permitteringsperiode",
-                  type: "periode",
-                },
-                {
-                  id: "faktum.arbeidsforhold-permitteringgrad",
-                  type: "int",
-                },
-              ],
+            },
+            {
+              id: "faktum.arbeidsforhold-permitteringgrad",
+              type: "int",
+              requiredAnswerIds: ["faktum.arbeidsforhold-aarsak.svar.permittert"],
             },
             {
               id: "faktum.arbeidsforhold-lonnsplinkt-arbeidsgiver",


### PR DESCRIPTION
Siden fagsiden har bestemt at det er i orden. Da slipper vi bruk av generatorfaktum inne i generatorfaktum.