### PR TITLE
DAG-317: Bytte ut react-datepicker med browser default datepicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@navikt/nav-dekoratoren-moduler": "^1.6.17",
         "@portabletext/react": "^1.0.6",
         "@portabletext/to-html": "^1.0.3",
+        "classnames": "^2.3.1",
         "date-fns": "^2.29.1",
         "i18n-iso-countries": "^7.5.0",
         "jsdom": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@navikt/nav-dekoratoren-moduler": "^1.6.17",
     "@portabletext/react": "^1.0.6",
     "@portabletext/to-html": "^1.0.3",
+    "classnames": "^2.3.1",
     "date-fns": "^2.29.1",
     "i18n-iso-countries": "^7.5.0",
     "jsdom": "^19.0.0",

--- a/src/components/date-picker/DatePicker.module.css
+++ b/src/components/date-picker/DatePicker.module.css
@@ -1,5 +1,32 @@
-.container input[readonly] {
+.datePicker {
+  display: flex;
+  flex-direction: column;
+  gap: var(--navds-spacing-2);
+}
+
+.datePickerInput {
+  padding: var(--navds-spacing-2);
+  background-color: var(--navds-text-field-color-background);
+  border-radius: var(--navds-border-radius-medium);
+  border: 1px solid var(--navds-text-field-color-border);
+  min-height: 48px;
+  width: 100%;
+  color: var(--navds-text-field-color-text);
   max-width: 200px;
   min-width: 120px;
-  cursor: pointer;
+}
+
+.datePickerInputError,
+.datePickerInputError:focus {
+  border-color: var(--navds-text-field-color-border-error);
+  box-shadow: 0 0 0 1px var(--navds-text-field-color-border-error);
+}
+
+.datePickerInputErrorLabel {
+  display: flex;
+  gap: var(--navds-spacing-2);
+}
+
+.datePickerInputErrorLabel:before {
+  content: "•";
 }


### PR DESCRIPTION
Byttet til browser default date picker.

- Slipper locale, dato formattering henter fra Operativ system
- Viser error melding ved onBlur dersom dato er ikke satt.
- Input feltet blir rødt på samme måten som andre input felter i Aksel komponent biblioteket.

Todo
- Mangler valideringer på hvor langt fram eller tilbake i tid man kan sette inn. Vi har en egen sak på det: https://jira.adeo.no/browse/DAG-269