### PR TITLE
DAG-351: Vis feilmelding hvis seksjonen ikke er ferdig utfylt når man trykker på neste

### DIFF
--- a/src/views/Soknad.tsx
+++ b/src/views/Soknad.tsx
@@ -34,7 +34,9 @@ export function Soknad() {
   }, []);
 
   useEffect(() => {
-    setShowNotFinishedError(false);
+    if (showNotFinishedError) {
+      setShowNotFinishedError(false);
+    }
   }, [soknadState]);
 
   function goNext() {


### PR DESCRIPTION
Neste knappen er nå synlig hele tiden. Hvis man klikker neste og man ikke har svart på alle spørsmål får man feilmelding


https://user-images.githubusercontent.com/9271099/183631906-3ceebe5f-4a5c-4b46-9b9f-5dfb9c1368ea.mov