### PR TITLE
DAG-368: Tar i bruk sanity-typer for dokumentkrav og dokumentkravSvar

### DIFF
--- a/src/__tests__/components/dokumentkrav/Dokumentkrav.test.tsx
+++ b/src/__tests__/components/dokumentkrav/Dokumentkrav.test.tsx
@@ -53,6 +53,8 @@ const mockSanity = {
   landgrupper: [],
   apptekster: [],
   startside: [],
+  dokumentkrav: [],
+  dokumentkravSvar: [],
 };
 
 describe("Dokumentkrav", () => {

--- a/src/__tests__/components/faktum/Faktum.test.tsx
+++ b/src/__tests__/components/faktum/Faktum.test.tsx
@@ -13,6 +13,8 @@ const mockSanity = {
   landgrupper: [],
   apptekster: [],
   startside: [],
+  dokumentkrav: [],
+  dokumentkravSvar: [],
 };
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {

--- a/src/__tests__/components/faktum/FaktumEnvalg.test.tsx
+++ b/src/__tests__/components/faktum/FaktumEnvalg.test.tsx
@@ -15,6 +15,8 @@ const mockSanity = {
   landgrupper: [],
   apptekster: [],
   startside: [],
+  dokumentkrav: [],
+  dokumentkravSvar: [],
 };
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {

--- a/src/__tests__/components/section/Section.test.tsx
+++ b/src/__tests__/components/section/Section.test.tsx
@@ -13,6 +13,8 @@ const mockSanity = {
   landgrupper: [],
   apptekster: [],
   startside: [],
+  dokumentkrav: [],
+  dokumentkravSvar: [],
 };
 
 const sectionMockData: IQuizSeksjon = {

--- a/src/components/dokumentkrav/Dokumentkrav.tsx
+++ b/src/components/dokumentkrav/Dokumentkrav.tsx
@@ -25,8 +25,8 @@ export function Dokumentkrav(props: IProps) {
   const [handledFiles, setHandlesFiles] = useState<IFileState[]>([]);
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   const [begrunnelse, setBegrunnelse] = useState(dokumentkrav.begrunnelse || ""); //TODO: Fjern eslint-disable når vi tar variabelen begrunnelse i bruk
-  const { getFaktumTextById, getSvaralternativTextById, getAppTekst } = useSanity();
-  const dokumentkravText = getFaktumTextById(dokumentkrav.beskrivendeId);
+  const { getDokumentkravTextById, getDokumentkravSvarTextById, getAppTekst } = useSanity();
+  const dokumentkravText = getDokumentkravTextById(dokumentkrav.beskrivendeId);
   const [alertText, setAlertText] = useState<ISanityAlertText>();
   const uploadedFiles: IDokumentkravFil[] = dokumentkrav.filer || [];
   const linkedArbeidsgiverFaktum = dokumentkrav.fakta.find((faktum) => {
@@ -35,7 +35,7 @@ export function Dokumentkrav(props: IProps) {
 
   useEffect(() => {
     if (svar !== "") {
-      setAlertText(getSvaralternativTextById(svar)?.alertText);
+      setAlertText(getDokumentkravSvarTextById(svar)?.alertText);
     }
   }, [svar]);
 
@@ -62,10 +62,11 @@ export function Dokumentkrav(props: IProps) {
           value={svar}
         >
           {dokumentkrav.gyldigeValg.map((textId) => {
-            const svaralternativText = getSvaralternativTextById(textId);
+            const id = `${dokumentkrav.id}-${textId}`;
+            const svaralternativText = getDokumentkravSvarTextById(textId);
             return (
-              <div key={textId}>
-                <Radio value={textId} id={textId}>
+              <div key={id}>
+                <Radio value={textId} id={id}>
                   {svaralternativText ? svaralternativText.text : textId}
                 </Radio>
               </div>
@@ -74,7 +75,7 @@ export function Dokumentkrav(props: IProps) {
         </RadioGroup>
       </div>
 
-      {alertText && alertText.active && <AlertText alertText={alertText} spacingTop />}
+      {alertText && <AlertText alertText={alertText} spacingTop />}
 
       {dokumentkravText?.helpText && (
         <HelpText className={styles.helpTextSpacing} helpText={dokumentkravText.helpText} />

--- a/src/context/sanity-context.tsx
+++ b/src/context/sanity-context.tsx
@@ -1,5 +1,7 @@
 import React, { PropsWithChildren } from "react";
 import {
+  ISanityDokumentkrav,
+  ISanityDokumentkravSvar,
   ISanityFaktum,
   ISanityLandGruppe,
   ISanitySeksjon,
@@ -50,6 +52,14 @@ function useSanity() {
     return context?.startside[0];
   }
 
+  function getDokumentkravTextById(textId: string): ISanityDokumentkrav | undefined {
+    return context?.dokumentkrav.find((krav) => krav.textId === textId);
+  }
+
+  function getDokumentkravSvarTextById(textId: string): ISanityDokumentkravSvar | undefined {
+    return context?.dokumentkravSvar.find((svar) => svar.textId === textId);
+  }
+
   return {
     getSeksjonTextById,
     getFaktumTextById,
@@ -57,6 +67,8 @@ function useSanity() {
     getSvaralternativTextById,
     getAppTekst,
     getStartsideText,
+    getDokumentkravTextById,
+    getDokumentkravSvarTextById,
   };
 }
 

--- a/src/sanity/groq-queries.ts
+++ b/src/sanity/groq-queries.ts
@@ -67,6 +67,33 @@ function getStartsideTextsFields() {
 }`;
 }
 
+function getDokumentkravFields(usePlainText: boolean) {
+  return `{
+  textId,
+  text,
+  ${usePlainText ? '"description": pt::text(description)' : "description"},
+  helpText,
+  helpText != null => {
+    "helpText": {
+      ...helpText, ${usePlainText ? '"body": pt::text(helpText.body)' : '"body": helpText.body'}
+    }
+  },
+}`;
+}
+
+function getDokumentkravSvarFields(usePlainText: boolean) {
+  return `{
+  textId,
+  text,
+  alertText,
+  alertText != null => {
+    "alertText": {
+      ...alertText, ${usePlainText ? '"body": pt::text(alertText.body)' : '"body": alertText.body'}
+    }
+  },
+}`;
+}
+
 function getSeksjonerGroq(usePlainText: boolean) {
   return `* [_type=="seksjon" && __i18n_lang==$baseLang]{
 ...coalesce(* [_id==^._id + "__i18n_" + $lang][0]${getSeksjonFields(
@@ -111,13 +138,31 @@ function getStartSideTextsGroq() {
   }`;
 }
 
+function getDokumentkravGroq(usePlainText: boolean) {
+  return `* [_type=="dokumentkrav" && __i18n_lang==$baseLang]{
+  ...coalesce(* [_id==^._id + "__i18n_" + $lang][0]${getDokumentkravFields(
+    usePlainText
+  )}, ${getDokumentkravFields(usePlainText)})
+  }`;
+}
+
+function getDokumentkravSvarGroq(usePlainText: boolean) {
+  return `* [_type=="dokumentkravSvar" && __i18n_lang==$baseLang]{
+  ...coalesce(* [_id==^._id + "__i18n_" + $lang][0]${getDokumentkravFields(
+    usePlainText
+  )}, ${getDokumentkravSvarFields(usePlainText)})
+  }`;
+}
+
 export const allTextsQuery = groq`{
   "seksjoner": ${getSeksjonerGroq(false)},
   "fakta": ${getFaktaGroq(false)},
   "svaralternativer": ${getSvaralternativerGroq(false)},
   "landgrupper": ${getLandGrupperGroq(false)},
   "apptekster": ${getAppTextsGroq()},
-  "startside": ${getStartSideTextsGroq()}
+  "startside": ${getStartSideTextsGroq()},
+  "dokumentkrav": ${getDokumentkravGroq(false)},
+  "dokumentkravSvar": ${getDokumentkravSvarGroq(false)}
 }`;
 
 export const allTextsPlainQuery = groq`{

--- a/src/types/sanity.types.ts
+++ b/src/types/sanity.types.ts
@@ -47,6 +47,19 @@ export interface ISanityStartSideTekst {
   body: TypedObject | TypedObject[];
 }
 
+export interface ISanityDokumentkrav {
+  textId: string;
+  text: string;
+  description?: TypedObject | TypedObject[];
+  helpText?: ISanityHelpText;
+}
+
+export interface ISanityDokumentkravSvar {
+  textId: string;
+  text: string;
+  alertText?: ISanityAlertText;
+}
+
 export interface ISanityTexts {
   fakta: ISanityFaktum[];
   seksjoner: ISanitySeksjon[];
@@ -54,4 +67,6 @@ export interface ISanityTexts {
   landgrupper: ISanityLandGruppe[];
   apptekster: ISanityAppTekst[];
   startside: ISanityStartSideTekst[];
+  dokumentkrav: ISanityDokumentkrav[];
+  dokumentkravSvar: ISanityDokumentkravSvar[];
 }


### PR DESCRIPTION
Tar i bruk sanity-typene for `dokumentkrav` (generell tekst per dokumentasjonskrav) og `dokumentkravSvar` (svarene på radioknappene). Fjerner også sjekk om `alertText.active` som jeg tror var miskopiert over fra annen kode. Det var i hvert fall ikke et felt som lenger fantes på alertText i Sanity, som gjorde at varselet aldri kom frem. 

Jeg er klar over at de mockede sanity-dataene per testsuite burde gjøres noe med, men tror jeg lar det ligge inntil videre. Sannsynligvis vil denne strukturen endres på uansett, og da kan vi inkludere å se hvor mocks skal ligge fremover. Arrester meg gjerne hvis dere synes dette burde fikses nå. 😄 

<img width="651" alt="image" src="https://user-images.githubusercontent.com/3233286/185912819-8ccafa80-eddb-4fec-a19d-9077c3d8a16c.png">
