### PR TITLE
Implementerer infoside på dokumentasjonssiden + startsiden

### DIFF
--- a/src/__tests__/components/dokumentkrav/Dokumentkrav.test.tsx
+++ b/src/__tests__/components/dokumentkrav/Dokumentkrav.test.tsx
@@ -55,6 +55,7 @@ const mockSanity = {
   startside: [],
   dokumentkrav: [],
   dokumentkravSvar: [],
+  infosider: [],
 };
 
 describe("Dokumentkrav", () => {

--- a/src/__tests__/components/faktum/Faktum.test.tsx
+++ b/src/__tests__/components/faktum/Faktum.test.tsx
@@ -15,6 +15,7 @@ const mockSanity = {
   startside: [],
   dokumentkrav: [],
   dokumentkravSvar: [],
+  infosider: [],
 };
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {

--- a/src/__tests__/components/faktum/FaktumEnvalg.test.tsx
+++ b/src/__tests__/components/faktum/FaktumEnvalg.test.tsx
@@ -17,6 +17,7 @@ const mockSanity = {
   startside: [],
   dokumentkrav: [],
   dokumentkravSvar: [],
+  infosider: [],
 };
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {

--- a/src/__tests__/components/section/Section.test.tsx
+++ b/src/__tests__/components/section/Section.test.tsx
@@ -15,6 +15,7 @@ const mockSanity = {
   startside: [],
   dokumentkrav: [],
   dokumentkravSvar: [],
+  infosider: [],
 };
 
 const sectionMockData: IQuizSeksjon = {

--- a/src/context/sanity-context.tsx
+++ b/src/context/sanity-context.tsx
@@ -3,9 +3,9 @@ import {
   ISanityDokumentkrav,
   ISanityDokumentkravSvar,
   ISanityFaktum,
+  ISanityInfoside,
   ISanityLandGruppe,
   ISanitySeksjon,
-  ISanityStartSideTekst,
   ISanitySvaralternativ,
   ISanityTexts,
 } from "../types/sanity.types";
@@ -72,8 +72,10 @@ function useSanity() {
     return text;
   }
 
-  function getStartsideText(): ISanityStartSideTekst | undefined {
-    return context?.startside[0];
+  function getInfosideText(slug: string): ISanityInfoside | undefined {
+    return context?.infosider.find((side) => {
+      return side.slug === slug;
+    });
   }
 
   function getDokumentkravTextById(textId: string): ISanityDokumentkrav | undefined {
@@ -90,9 +92,9 @@ function useSanity() {
     getLandGruppeTextById,
     getSvaralternativTextById,
     getAppTekst,
-    getStartsideText,
     getDokumentkravTextById,
     getDokumentkravSvarTextById,
+    getInfosideText,
   };
 }
 

--- a/src/sanity/groq-queries.ts
+++ b/src/sanity/groq-queries.ts
@@ -61,8 +61,9 @@ function getAppTextsFields() {
 }`;
 }
 
-function getStartsideTextsFields() {
+function getInfosideFields() {
   return `{
+  "slug": slug.current,
   body
 }`;
 }
@@ -132,9 +133,9 @@ function getAppTextsGroq() {
   }`;
 }
 
-function getStartSideTextsGroq() {
-  return `* [_type=="startside" && __i18n_lang==$baseLang]{
-  ...coalesce(* [_id==^._id + "__i18n_" + $lang][0]${getStartsideTextsFields()}, ${getStartsideTextsFields()})
+function getInfosiderGroq() {
+  return `* [_type=="infopage"  && __i18n_lang==$baseLang]{
+  ...coalesce(* [_id==^._id + "__i18n_" + $lang][0]${getInfosideFields()}, ${getInfosideFields()})
   }`;
 }
 
@@ -160,9 +161,9 @@ export const allTextsQuery = groq`{
   "svaralternativer": ${getSvaralternativerGroq(false)},
   "landgrupper": ${getLandGrupperGroq(false)},
   "apptekster": ${getAppTextsGroq()},
-  "startside": ${getStartSideTextsGroq()},
   "dokumentkrav": ${getDokumentkravGroq(false)},
-  "dokumentkravSvar": ${getDokumentkravSvarGroq(false)}
+  "dokumentkravSvar": ${getDokumentkravSvarGroq(false)},
+  "infosider": ${getInfosiderGroq()}
 }`;
 
 export const allTextsPlainQuery = groq`{

--- a/src/types/sanity.types.ts
+++ b/src/types/sanity.types.ts
@@ -43,7 +43,8 @@ export interface ISanityAppTekst {
   valueText: string;
 }
 
-export interface ISanityStartSideTekst {
+export interface ISanityInfoside {
+  slug: string;
   body: TypedObject | TypedObject[];
 }
 
@@ -66,7 +67,7 @@ export interface ISanityTexts {
   svaralternativer: ISanitySvaralternativ[];
   landgrupper: ISanityLandGruppe[];
   apptekster: ISanityAppTekst[];
-  startside: ISanityStartSideTekst[];
   dokumentkrav: ISanityDokumentkrav[];
   dokumentkravSvar: ISanityDokumentkravSvar[];
+  infosider: ISanityInfoside[];
 }

--- a/src/views/Dokumentasjonskrav.tsx
+++ b/src/views/Dokumentasjonskrav.tsx
@@ -1,4 +1,5 @@
-import { Detail, Heading } from "@navikt/ds-react";
+import { Detail } from "@navikt/ds-react";
+import { PortableText } from "@portabletext/react";
 import React from "react";
 import { Dokumentkrav } from "../components/dokumentkrav/Dokumentkrav";
 import { useSanity } from "../context/sanity-context";
@@ -10,13 +11,12 @@ interface IProps {
 }
 
 export function Dokumentasjonskrav(props: IProps) {
-  const { getAppTekst } = useSanity();
+  const { getAppTekst, getInfosideText } = useSanity();
   const { dokumentasjonskrav } = props;
+  const dokumentasjonskravText = getInfosideText("dokumentasjonskrav");
   return (
     <>
-      <Heading level="2" size="medium">
-        Dokumentasjon
-      </Heading>
+      {dokumentasjonskravText?.body && <PortableText value={dokumentasjonskravText.body} />}
       {dokumentasjonskrav.krav.map((krav, index) => {
         const formattedCounter = `${index + 1} ${getAppTekst("dokumentkrav.nummer.av.krav")} ${
           dokumentasjonskrav.krav.length

--- a/src/views/StartSoknad.tsx
+++ b/src/views/StartSoknad.tsx
@@ -14,7 +14,7 @@ export function StartSoknad() {
   const [isCreatingSoknadUUID, setIsCreatingSoknadUUID] = useState(false);
   const [consentGiven, setConsentGiven] = useState<boolean>(false);
   const [isError, setIsError] = useState(false);
-  const { getAppTekst, getStartsideText } = useSanity();
+  const { getAppTekst, getInfosideText } = useSanity();
 
   async function startSoknad() {
     try {
@@ -33,7 +33,7 @@ export function StartSoknad() {
     }
   }
 
-  const startSideText = getStartsideText();
+  const startSideText = getInfosideText("startside");
   const portableTextComponents = { types: { timeline } };
 
   if (isError) {


### PR DESCRIPTION
Lager en enkel uthenting av alle infosider og henter de ut og viser de på startsiden og dokumentasjonskrav-siden. 

I dag henter vi ut sanity-tekstene på nytt per side i NextJS. Vi har diskutert om vi skal gjøre uthentingen smartere og kun hente det vi trenger per side, men fordi vi i fremtiden ønsker å hente ut sanity-tekster én gang, og ikke en gang per side slik som nå, skipper jeg det inntil videre.