### PR TITLE
DAG-371: Legger dokumentasjonssiden som eget steg i søknadsflyten før oppsummering

### DIFF
--- a/src/views/Dokumentasjonskrav.tsx
+++ b/src/views/Dokumentasjonskrav.tsx
@@ -1,4 +1,4 @@
-import { Detail } from "@navikt/ds-react";
+import { Alert, Button, Detail } from "@navikt/ds-react";
 import { PortableText } from "@portabletext/react";
 import React from "react";
 import { Dokumentkrav } from "../components/dokumentkrav/Dokumentkrav";
@@ -6,15 +6,28 @@ import { useSanity } from "../context/sanity-context";
 import { IDokumentkravListe } from "../types/documentation.types";
 import { NoSessionModal } from "../components/no-session-modal/NoSessionModal";
 import styles from "./Dokumentasjonskrav.module.css";
+import soknadStyles from "./Soknad.module.css";
+import { useRouter } from "next/router";
+import { Left } from "@navikt/ds-icons";
 
 interface IProps {
   dokumentasjonskrav: IDokumentkravListe;
 }
 
 export function Dokumentasjonskrav(props: IProps) {
+  const router = useRouter();
   const { getAppTekst, getInfosideText } = useSanity();
   const { dokumentasjonskrav } = props;
   const dokumentasjonskravText = getInfosideText("dokumentasjonskrav");
+
+  function goToSummary() {
+    router.push(`/${router.query.uuid}/oppsummering`);
+  }
+
+  function goToSoknad() {
+    router.push(`/${router.query.uuid}`);
+  }
+
   return (
     <>
       {dokumentasjonskravText?.body && <PortableText value={dokumentasjonskravText.body} />}
@@ -29,6 +42,18 @@ export function Dokumentasjonskrav(props: IProps) {
           </div>
         );
       })}
+
+      <Alert variant="info" size="medium">
+        {getAppTekst("dokumentasjonskrav.ingen.krav.funnet")}
+      </Alert>
+
+      <nav className={soknadStyles.navigation}>
+        <Button variant={"secondary"} onClick={() => goToSoknad()} icon={<Left />}>
+          {getAppTekst("knapp.forrige")}
+        </Button>
+
+        <Button onClick={() => goToSummary()}>{getAppTekst("soknad.til-oppsummering")}</Button>
+      </nav>
 
       <NoSessionModal />
     </>

--- a/src/views/Soknad.tsx
+++ b/src/views/Soknad.tsx
@@ -23,6 +23,7 @@ export function Soknad() {
 
   const currentSection = soknadState.seksjoner[sectionIndex];
   const isFirstSection = sectionIndex === 0;
+  const isLastSection = sectionIndex === soknadState.seksjoner.length - 1;
   const firstUnansweredFaktumIndex = currentSection?.fakta?.findIndex(
     (faktum) => faktum?.svar === undefined
   );
@@ -56,8 +57,8 @@ export function Soknad() {
     router.push(`/${router.query.uuid}?seksjon=${nextIndex}`, undefined, { shallow: true });
   }
 
-  async function goToSummary() {
-    router.push(`/${router.query.uuid}/oppsummering`);
+  function goToDocumentation() {
+    router.push(`/${router.query.uuid}/dokumentasjon`);
   }
 
   function cancelSoknad() {
@@ -102,14 +103,16 @@ export function Soknad() {
           </Button>
         )}
 
-        {!soknadState.ferdig && (
+        {!isLastSection && (
           <Button onClick={() => goNext()} icon={<Right />} iconPosition={"right"}>
             {getAppTekst("knapp.neste")}
           </Button>
         )}
 
-        {soknadState.ferdig && (
-          <Button onClick={() => goToSummary()}>{getAppTekst("soknad.til-oppsummering")}</Button>
+        {isLastSection && soknadState.ferdig && (
+          <Button onClick={() => goToDocumentation()}>
+            {getAppTekst("soknad.til-dokumentasjon")}
+          </Button>
         )}
       </nav>
 

--- a/src/views/Summary.tsx
+++ b/src/views/Summary.tsx
@@ -21,8 +21,8 @@ export function Summary(props: IProps) {
   const router = useRouter();
   const { getAppTekst, getSeksjonTextById } = useSanity();
 
-  function goToSoknad() {
-    router.push(`/${router.query.uuid}`);
+  function goToDocumentation() {
+    router.push(`/${router.query.uuid}/dokumentasjon`);
   }
 
   function cancelSoknad() {
@@ -81,7 +81,7 @@ export function Summary(props: IProps) {
       </ConfirmationPanel>
 
       <nav className={styles.navigation}>
-        <Button variant={"secondary"} onClick={() => goToSoknad()} icon={<Left />}>
+        <Button variant={"secondary"} onClick={() => goToDocumentation()} icon={<Left />}>
           {getAppTekst("knapp.forrige")}
         </Button>
 


### PR DESCRIPTION
Vi antar at vi alltid skal komme til dokumentasjonssiden før vi ser oppsummeringen og sender søknad. De fleste vil ha dokumentasjonskrav de må svare på, men vi kommer også til å vise en generell opplasting på siden for "Annet". Dermed kan vi hardkode at vi alltid skal komme til dette steget i stedet for å sjekke om bruker har dokumentkrav å svare på.