### PR TITLE
Rettet feil som gjorde at EØS-arbeidsforhold alltid ble markert som "delvis utfylt"

### DIFF
--- a/src/components/faktum/FaktumGenerator.tsx
+++ b/src/components/faktum/FaktumGenerator.tsx
@@ -50,9 +50,11 @@ function StandardGenerator(props: IFaktum<IQuizGeneratorFaktum>) {
   return (
     <>
       {props.faktum?.svar?.map((fakta, svarIndex) => {
+        const unansweredFaktum = fakta.find((faktum) => faktum?.svar === undefined);
         return (
           <div key={svarIndex}>
             <GeneratorFaktumCard
+              allFaktumAnswered={!unansweredFaktum}
               editFaktum={() => toggleActiveGeneratorAnswer(svarIndex)}
               deleteFaktum={() => deleteGeneratorAnswer(props.faktum, svarIndex)}
             >


### PR DESCRIPTION
Sørger for at komponenten "GeneratorFaktumCard" blir brukt på samme måte alle steder i koden. Fant et sted hvor parameteret "allFaktumAnswered" ikke ble sendt med.

En enda bedre løsning hadde vært om GeneratorFaktumCard tar inn listen av fakta som et påkrevd parameter, og selv avgjør om den inneholder ubesvarte fakta. Da hadde vi sluppet denne feilen, og vi er sikret at komponenten blir brukt likt alle steder.