### PR TITLE
DAG-438: Forskjellige begrunnelsesfelt per svar som krever begrunnelse

### DIFF
--- a/src/components/dokumentkrav/Dokumentkrav.test.tsx
+++ b/src/components/dokumentkrav/Dokumentkrav.test.tsx
@@ -87,7 +87,9 @@ describe("Dokumentkrav", () => {
     await user.click(screen.getByLabelText("dokumentkrav.svar.sender.ikke"));
 
     await waitFor(() => {
-      expect(screen.getByLabelText("dokumentkrav.sender.ikke.naa.begrunnelse")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("dokumentkrav.svar.sender.ikke.begrunnelse")
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/components/dokumentkrav/Dokumentkrav.tsx
+++ b/src/components/dokumentkrav/Dokumentkrav.tsx
@@ -174,6 +174,7 @@ export function Dokumentkrav(props: IProps) {
       {svar && svar !== DOKUMENTKRAV_SVAR_SEND_NAA && (
         <DokumentkravBegrunnelse
           begrunnelse={begrunnelse}
+          svar={svar}
           setBegrunnelse={setBegrunnelse}
           validationError={validationError}
         />

--- a/src/components/dokumentkrav/DokumentkravBegrunnelse.tsx
+++ b/src/components/dokumentkrav/DokumentkravBegrunnelse.tsx
@@ -4,6 +4,7 @@ import { TextField } from "@navikt/ds-react";
 import { useSanity } from "../../context/sanity-context";
 import { useDebouncedCallback } from "../../hooks/useDebouncedCallback";
 import { useFirstRender } from "../../hooks/useFirstRender";
+import { PortableText } from "@portabletext/react";
 
 interface IProps {
   begrunnelse: string | undefined;
@@ -43,6 +44,9 @@ export function DokumentkravBegrunnelse({
         size="medium"
         defaultValue={begrunnelse}
         label={begrunnelseText ? begrunnelseText.text : textId}
+        description={
+          begrunnelseText?.description && <PortableText value={begrunnelseText.description} />
+        }
         onChange={(event) => debouncedBegrunnelse(event.currentTarget.value)}
         error={
           !begrunnelse &&

--- a/src/components/dokumentkrav/DokumentkravBegrunnelse.tsx
+++ b/src/components/dokumentkrav/DokumentkravBegrunnelse.tsx
@@ -1,18 +1,40 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styles from "./Dokumentkrav.module.css";
 import { TextField } from "@navikt/ds-react";
 import { useSanity } from "../../context/sanity-context";
 import { useDebouncedCallback } from "../../hooks/useDebouncedCallback";
+import { useFirstRender } from "../../hooks/useFirstRender";
 
 interface IProps {
   begrunnelse: string | undefined;
+  svar: string | undefined;
   setBegrunnelse: (value: string) => void;
   validationError?: boolean;
 }
 
-export function DokumentkravBegrunnelse({ begrunnelse, setBegrunnelse, validationError }: IProps) {
-  const { getAppTekst } = useSanity();
+export function DokumentkravBegrunnelse({
+  begrunnelse,
+  svar,
+  setBegrunnelse,
+  validationError,
+}: IProps) {
+  const { getAppTekst, getDokumentkravTextById } = useSanity();
   const debouncedBegrunnelse = useDebouncedCallback(setBegrunnelse, 500);
+  const isFirstRender = useFirstRender();
+
+  useEffect(() => {
+    if (isFirstRender) {
+      return;
+    }
+    // Reset begrunnelse if user selects new answer
+    // (a trade off necessary since we're using one field to represent four different begrunnelse)
+    if (begrunnelse && begrunnelse !== "") {
+      setBegrunnelse("");
+    }
+  }, [svar]);
+
+  const textId = `${svar}.begrunnelse`;
+  const begrunnelseText = getDokumentkravTextById(textId);
 
   return (
     <div className={styles.dokumentkravBegrunnelse}>
@@ -20,7 +42,7 @@ export function DokumentkravBegrunnelse({ begrunnelse, setBegrunnelse, validatio
         type="text"
         size="medium"
         defaultValue={begrunnelse}
-        label={getAppTekst("dokumentkrav.sender.ikke.naa.begrunnelse")}
+        label={begrunnelseText ? begrunnelseText.text : textId}
         onChange={(event) => debouncedBegrunnelse(event.currentTarget.value)}
         error={
           !begrunnelse &&


### PR DESCRIPTION
Per dokumentkrav har man fire forskjellige svar som brukeren kan velge som alle krever at bruker også skriver inn en begrunnelse. Eksempelvis **dokumentkrav.svar.send.senere.begrunnelse**:
<img width="679" alt="image" src="https://user-images.githubusercontent.com/3233286/193850875-87ee06b7-36b8-49d7-b647-1e25b6fbf370.png">

Dette feltet skal ha egne label-tekster, noen ganger egen beskrivelse, og etter hvert custom feilmeldinger per input. Alle disse begrunnelsene skal postes til ett og samme felt i dp-soknad per dokumentkrav. Derfor må vi cleare ut feltet hver gang brukeren velger et nytt svar hen må skrive en begrunnelse for. Å ta vare på svaret i minne hadde vært for mye jobb, og ikke noe som ellers skjer i søknadsdialogen. 