### PR TITLE
Lager egen hook for å håndtere seksjonene i søknadsdialogen

### DIFF
--- a/src/hooks/soknad/useSectionManager.ts
+++ b/src/hooks/soknad/useSectionManager.ts
@@ -1,0 +1,42 @@
+import { useRouter } from "next/router";
+import { IQuizState } from "../../localhost-data/quiz-state-response";
+
+export function useSectionManager(soknadState: IQuizState) {
+  const router = useRouter();
+
+  const sectionParam = parseInt(router.query.seksjon as string);
+
+  const isValidSection = sectionParam && !!soknadState.seksjoner[sectionParam - 1];
+
+  let sectionIndex, nextSectionParam, previousSectionParam;
+
+  if (!isNaN(sectionParam) && isValidSection) {
+    sectionIndex = sectionParam - 1;
+
+    nextSectionParam = sectionParam + 1;
+    previousSectionParam = sectionParam - 1;
+  } else {
+    // Show first section if nothing else is specified
+    sectionIndex = 0;
+    nextSectionParam = 2;
+  }
+
+  const isFirstSection = sectionIndex === 0;
+  const currentSection = soknadState.seksjoner[sectionIndex];
+
+  const firstUnansweredFaktumIndex = currentSection?.fakta?.findIndex(
+    (faktum) => faktum?.svar === undefined
+  );
+
+  const nextUnansweredFaktumIndex =
+    firstUnansweredFaktumIndex === -1 ? currentSection.fakta.length : firstUnansweredFaktumIndex;
+
+  return {
+    isFirstSection,
+    isValidSection,
+    nextSectionParam,
+    previousSectionParam,
+    currentSection,
+    nextUnansweredFaktumIndex,
+  };
+}


### PR DESCRIPTION
`views/Soknad.tsx` sin logikk vokser og vokser. For å bøte på det legger jeg den manuelle håndteringen av seksjoner ut i en egen hook. Har også forsøkt å forenkle noe av logikken rundt forrige/neste seksjon som kan navigeres til, og default seksjon som settes hvis ingenting annet er satt.

Det var ganske komplisert logikk her, så pull gjerne ned endringene og klikk igjennom søknaden for å se om det er noe jeg har gått glipp av. Jeg har testet dette godt på min maskin, men det kan godt hende det er noe jeg har sett meg blind på. 😄 

Dette er ikke ment som en full omskriving. Det er som sagt overraskende komplisert, og mye av logikken har jeg rett og slett flyttet direkte over til hooken. Her kan mye gjøres i en ideell verden, men jeg anser det som feil å gjøre på grunn av [skalaen på en slik oppgave](https://csswizardry.com/2017/06/refactoring-tunnels/).