### PR TITLE
DAG-556: Warning tekst dersom henting av arbeidssøker status feilet

### DIFF
--- a/src/components/inngang-paabegynt/InngangPaabegynt.tsx
+++ b/src/components/inngang-paabegynt/InngangPaabegynt.tsx
@@ -1,45 +1,21 @@
 import { BodyLong, Button } from "@navikt/ds-react";
 import Link from "next/link";
-import { useRouter } from "next/router";
-import { useState } from "react";
-import { deleteSoknad } from "../../api/deleteSoknad-api";
 import { useSanity } from "../../context/sanity-context";
-import { IArbeidssokerStatus } from "../../pages/api/arbeidssoker";
-import { ErrorTypesEnum } from "../../types/error.types";
 import { IPaabegyntSoknad } from "../../types/quiz.types";
-import { ErrorRetryModal } from "../error-retry-modal/ErrorRetryModal";
 import { FormattedDate } from "../FormattedDate";
 import styles from "./inngangPaabegynt.module.css";
 
 interface IProps {
   paabegynt: IPaabegyntSoknad;
-  arbeidssokerStatus?: IArbeidssokerStatus;
 }
-export function InngangPaabegynt({ paabegynt, arbeidssokerStatus }: IProps) {
-  const router = useRouter();
+export function InngangPaabegynt({ paabegynt }: IProps) {
   const { getAppText } = useSanity();
-
-  const [isLoading, setIsLoading] = useState(false);
-  const [hasError, setHasError] = useState(false);
-
-  async function deleteSoknadAndNavigateToFrontPage() {
-    setIsLoading(true);
-    const deleteSoknadResponse = await deleteSoknad(paabegynt.soknadUuid);
-
-    if (deleteSoknadResponse.ok) {
-      router.push("/");
-    } else {
-      setIsLoading(false);
-      setHasError(true);
-      throw new Error(deleteSoknadResponse.statusText);
-    }
-  }
 
   return (
     <div className={styles.inngangPaabegyntContainer}>
       <BodyLong>
         {getAppText("inngang.paabegyntsoknad.header.du-har-en-paabegynt")}{" "}
-        <FormattedDate date={paabegynt.opprettet} />.{" "}
+        <FormattedDate date={paabegynt.sistEndretAvbruker ?? paabegynt.opprettet} />.{" "}
         {getAppText("inngang.paabegyntsoknad.header.fortsett-eller-starte-ny")}
       </BodyLong>
       <Link href={paabegynt.soknadUuid} passHref>
@@ -47,23 +23,11 @@ export function InngangPaabegynt({ paabegynt, arbeidssokerStatus }: IProps) {
           {getAppText("inngang.paabegyntsoknad.fortsett-paabegynt-knapp")}
         </Button>
       </Link>
-      {arbeidssokerStatus === "REGISTERED" && (
-        <Button
-          variant="secondary"
-          onClick={deleteSoknadAndNavigateToFrontPage}
-          loading={isLoading}
-        >
+      <Link href="/arbeidssoker" passHref>
+        <Button variant="secondary" as="a">
           {getAppText("inngang.paabegyntsoknad.start-en-ny-knapp")}
         </Button>
-      )}
-      {arbeidssokerStatus !== "REGISTERED" && (
-        <Link href="/arbeidssoker" passHref>
-          <Button variant="secondary" as="a">
-            {getAppText("inngang.paabegyntsoknad.start-en-ny-knapp")}
-          </Button>
-        </Link>
-      )}
-      {hasError && <ErrorRetryModal errorType={ErrorTypesEnum.GenericError} />}
+      </Link>
     </div>
   );
 }

--- a/src/pages/arbeidssoker.tsx
+++ b/src/pages/arbeidssoker.tsx
@@ -1,14 +1,22 @@
 import { getSession } from "@navikt/dp-auth/server";
 import { GetServerSidePropsContext, GetServerSidePropsResult } from "next/types";
 import { sanityClient } from "../../sanity-client";
+import { audienceDPSoknad } from "../api.utils";
+import { getArbeidssokerperioder, IArbeidssokerperioder } from "../api/arbeidssoker-api";
 import { SanityProvider } from "../context/sanity-context";
 import { allTextsQuery } from "../sanity/groq-queries";
+import { IMineSoknader } from "../types/quiz.types";
 import { ISanityTexts } from "../types/sanity.types";
 import { Arbeidssoker } from "../views/arbeidssoker/Arbeidssoker";
+import { IArbeidssokerStatus } from "./api/arbeidssoker";
+import { getMineSoknader } from "./api/soknad/get-mine-soknader";
 import ErrorPage from "./_error";
 
 interface IProps {
   sanityTexts: ISanityTexts;
+  mineSoknader: IMineSoknader | null;
+  arbeidssokerStatus: IArbeidssokerStatus;
+  errorCode: number | null;
 }
 
 export async function getServerSideProps(
@@ -25,6 +33,19 @@ export async function getServerSideProps(
     return {
       props: {
         sanityTexts,
+        mineSoknader: {
+          paabegynt: {
+            soknadUuid: "localhost-uuid-paabegynt",
+            opprettet: "2022-10-20T15:15:06.913514",
+            sistEndretAvbruker: "2022-11-20T15:15:06.913514",
+          },
+          innsendte: [
+            { soknadUuid: "localhost-uuid-innsendt-1", forstInnsendt: "2022-10-21T09:47:29" },
+            { soknadUuid: "localhost-uuid-innsent-2", forstInnsendt: "2022-10-21T09:42:37" },
+          ],
+        },
+        arbeidssokerStatus: "REGISTERED",
+        errorCode: null,
       },
     };
   }
@@ -39,15 +60,55 @@ export async function getServerSideProps(
     };
   }
 
+  let mineSoknader = null;
+  let arbeidssokerStatus: IArbeidssokerStatus;
+  let errorCode = null;
+
+  const onBehalfOfToken = await apiToken(audienceDPSoknad);
+  const mineSoknaderResponse = await getMineSoknader(onBehalfOfToken);
+  const arbeidssokerStatusResponse = await getArbeidssokerperioder(context);
+
+  if (!mineSoknaderResponse.ok) {
+    errorCode = mineSoknaderResponse.status;
+  } else {
+    mineSoknader = await mineSoknaderResponse.json();
+  }
+
+  if (arbeidssokerStatusResponse.ok) {
+    const data: IArbeidssokerperioder = await arbeidssokerStatusResponse.json();
+    const currentArbeidssokerperiodeIndex = data.arbeidssokerperioder.findIndex(
+      (periode) => periode.tilOgMedDato === null
+    );
+
+    arbeidssokerStatus = currentArbeidssokerperiodeIndex !== -1 ? "REGISTERED" : "UNREGISTERED";
+  } else {
+    arbeidssokerStatus = "UNKNOWN";
+  }
+
   return {
     props: {
       sanityTexts,
+      mineSoknader,
+      arbeidssokerStatus,
+      errorCode,
     },
   };
 }
 
-export default function InngangPage(props: IProps) {
-  if (!props.sanityTexts.seksjoner) {
+export default function InngangPage({ sanityTexts, arbeidssokerStatus, mineSoknader }: IProps) {
+  const soknadUuid = mineSoknader?.paabegynt?.soknadUuid;
+
+  if (!soknadUuid) {
+    return (
+      <ErrorPage
+        title="Det har skjedd en teknisk feil"
+        details="Beklager, vi mistet kontakten med systemene våre."
+        statusCode={500}
+      />
+    );
+  }
+
+  if (!sanityTexts.seksjoner) {
     return (
       <ErrorPage
         title="Det har skjedd en teknisk feil"
@@ -58,8 +119,8 @@ export default function InngangPage(props: IProps) {
   }
 
   return (
-    <SanityProvider initialState={props.sanityTexts}>
-      <Arbeidssoker />
+    <SanityProvider initialState={sanityTexts}>
+      <Arbeidssoker soknadUuid={soknadUuid} arbeidssokerStatus={arbeidssokerStatus} />
     </SanityProvider>
   );
 }

--- a/src/pages/inngang.tsx
+++ b/src/pages/inngang.tsx
@@ -2,20 +2,17 @@ import { getSession } from "@navikt/dp-auth/server";
 import { GetServerSidePropsContext, GetServerSidePropsResult } from "next/types";
 import { sanityClient } from "../../sanity-client";
 import { audienceDPSoknad } from "../api.utils";
-import { getArbeidssokerperioder, IArbeidssokerperioder } from "../api/arbeidssoker-api";
 import { SanityProvider } from "../context/sanity-context";
 import { allTextsQuery } from "../sanity/groq-queries";
 import { IMineSoknader } from "../types/quiz.types";
 import { ISanityTexts } from "../types/sanity.types";
 import { Inngang } from "../views/Inngang";
-import { IArbeidssokerStatus } from "./api/arbeidssoker";
 import { getMineSoknader } from "./api/soknad/get-mine-soknader";
 import ErrorPage from "./_error";
 
 interface IProps {
   sanityTexts: ISanityTexts;
   mineSoknader: IMineSoknader | null;
-  arbeidssokerStatus: IArbeidssokerStatus;
   errorCode: number | null;
 }
 
@@ -37,13 +34,13 @@ export async function getServerSideProps(
           paabegynt: {
             soknadUuid: "localhost-uuid-paabegynt",
             opprettet: "2022-10-20T15:15:06.913514",
+            sistEndretAvbruker: "2022-11-20T15:15:06.913514",
           },
           innsendte: [
             { soknadUuid: "localhost-uuid-innsendt-1", forstInnsendt: "2022-10-21T09:47:29" },
             { soknadUuid: "localhost-uuid-innsent-2", forstInnsendt: "2022-10-21T09:42:37" },
           ],
         },
-        arbeidssokerStatus: "UNREGISTERED",
         errorCode: null,
       },
     };
@@ -61,11 +58,9 @@ export async function getServerSideProps(
 
   let mineSoknader = null;
   let errorCode = null;
-  let arbeidssokerStatus: IArbeidssokerStatus;
 
   const onBehalfOfToken = await apiToken(audienceDPSoknad);
   const mineSoknaderResponse = await getMineSoknader(onBehalfOfToken);
-  const arbeidssokerStatusResponse = await getArbeidssokerperioder(context);
 
   if (!mineSoknaderResponse.ok) {
     errorCode = mineSoknaderResponse.status;
@@ -73,29 +68,17 @@ export async function getServerSideProps(
     mineSoknader = await mineSoknaderResponse.json();
   }
 
-  if (arbeidssokerStatusResponse.ok) {
-    const data: IArbeidssokerperioder = await arbeidssokerStatusResponse.json();
-    const currentArbeidssokerperiodeIndex = data.arbeidssokerperioder.findIndex(
-      (periode) => periode.tilOgMedDato === null
-    );
-
-    arbeidssokerStatus = currentArbeidssokerperiodeIndex !== -1 ? "REGISTERED" : "UNREGISTERED";
-  } else {
-    arbeidssokerStatus = "UNKNOWN";
-  }
-
   return {
     props: {
       sanityTexts,
       mineSoknader,
-      arbeidssokerStatus,
       errorCode,
     },
   };
 }
 
 export default function InngangPage(props: IProps) {
-  const { errorCode, mineSoknader, arbeidssokerStatus, sanityTexts } = props;
+  const { errorCode, mineSoknader, sanityTexts } = props;
 
   if (errorCode) {
     return (
@@ -119,11 +102,7 @@ export default function InngangPage(props: IProps) {
 
   return (
     <SanityProvider initialState={sanityTexts}>
-      <Inngang
-        paabegynt={mineSoknader?.paabegynt}
-        innsendte={mineSoknader?.innsendte}
-        arbeidssokerStatus={arbeidssokerStatus}
-      />
+      <Inngang paabegynt={mineSoknader?.paabegynt} innsendte={mineSoknader?.innsendte} />
     </SanityProvider>
   );
 }

--- a/src/types/quiz.types.ts
+++ b/src/types/quiz.types.ts
@@ -101,6 +101,7 @@ export type QuizFaktumSvarType =
 export interface IPaabegyntSoknad {
   soknadUuid: string;
   opprettet: string;
+  sistEndretAvbruker?: string;
 }
 
 export interface IInnsentSoknad {

--- a/src/views/Inngang.tsx
+++ b/src/views/Inngang.tsx
@@ -1,21 +1,17 @@
 import { InngangPaabegynt } from "../components/inngang-paabegynt/InngangPaabegynt";
 import { InngangSendDocument } from "../components/inngang-send-document/InngangSendDocument";
-import { IArbeidssokerStatus } from "../pages/api/arbeidssoker";
 import { IInnsentSoknad, IPaabegyntSoknad } from "../types/quiz.types";
 
 interface IProps {
   paabegynt?: IPaabegyntSoknad;
   innsendte?: IInnsentSoknad[];
-  arbeidssokerStatus?: IArbeidssokerStatus;
 }
 
-export function Inngang({ paabegynt, innsendte, arbeidssokerStatus }: IProps) {
+export function Inngang({ paabegynt, innsendte }: IProps) {
   return (
     <>
       {innsendte && <InngangSendDocument innsendte={innsendte} />}
-      {paabegynt && (
-        <InngangPaabegynt paabegynt={paabegynt} arbeidssokerStatus={arbeidssokerStatus} />
-      )}
+      {paabegynt && <InngangPaabegynt paabegynt={paabegynt} />}
     </>
   );
 }

--- a/src/views/arbeidssoker/Arbeidssoker.module.css
+++ b/src/views/arbeidssoker/Arbeidssoker.module.css
@@ -1,3 +1,3 @@
-.arbeidssokerLinkContainer {
-  margin-top: var(--navds-spacing-6);
+.arbeidssokerStatusErrorWarning {
+  margin-top: var(--navds-spacing-2);
 }

--- a/src/views/arbeidssoker/Arbeidssoker.tsx
+++ b/src/views/arbeidssoker/Arbeidssoker.tsx
@@ -1,31 +1,81 @@
-import { BodyLong, Button, Heading } from "@navikt/ds-react";
+import { Alert, BodyLong, Button, Heading } from "@navikt/ds-react";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { deleteSoknad } from "../../api/deleteSoknad-api";
+import { ErrorRetryModal } from "../../components/error-retry-modal/ErrorRetryModal";
 import { useSanity } from "../../context/sanity-context";
+import { IArbeidssokerStatus } from "../../pages/api/arbeidssoker";
+import { ErrorTypesEnum } from "../../types/error.types";
 import styles from "./Arbeidssoker.module.css";
+interface IProps {
+  soknadUuid: string;
+  arbeidssokerStatus: IArbeidssokerStatus;
+}
 
-export function Arbeidssoker() {
+export function Arbeidssoker({ soknadUuid, arbeidssokerStatus }: IProps) {
   const { getAppText } = useSanity();
+  const router = useRouter();
+  const [hasDeleteSoknadError, setHasDeleteSoknadError] = useState(false);
+
+  useEffect(() => {
+    if (arbeidssokerStatus === "REGISTERED") {
+      deleteSoknadAndNavigateToFrontPage();
+    }
+  }, []);
+
+  async function deleteSoknadAndNavigateToFrontPage() {
+    const deleteSoknadResponse = await deleteSoknad(soknadUuid);
+
+    if (deleteSoknadResponse.ok) {
+      router.push("/");
+    } else {
+      setHasDeleteSoknadError(true);
+      throw new Error(deleteSoknadResponse.statusText);
+    }
+  }
 
   return (
     <>
-      <Heading level="2" size="small">
-        {getAppText("arbeidssoker.header")}
-      </Heading>
-      <BodyLong>{getAppText("arbeidssoker.beskrivelse")}</BodyLong>
-      <div className="navigation-container">
-        <Link href="https://arbeidssokerregistrering.nav.no/" passHref>
-          <Button variant="primary" as="a">
-            {getAppText("arbeidssoker.registrer-som-arbeidssoker-knapp")}
-          </Button>
-        </Link>
-        <Link href={`https://www.nav.no/no/ditt-nav`} passHref>
-          <Button variant="secondary">{getAppText("arbeidssoker.avbryt-knapp")}</Button>
-        </Link>
-      </div>
-      <BodyLong className={styles.arbeidssokerLinkContainer}>
-        <Link href="/">{getAppText("arbeidssoker.sok-om-dagpenger-likevel.lenke-tekst")}</Link>{" "}
-        {getAppText("arbeidssoker.sok-om-dagpenger-likevel.beskrivelse")}
-      </BodyLong>
+      {arbeidssokerStatus === "UNREGISTERED" && (
+        <>
+          <Heading level="2" size="small">
+            {getAppText("arbeidssoker.header")}
+          </Heading>
+          <BodyLong>{getAppText("arbeidssoker.beskrivelse")}</BodyLong>
+          <div className="navigation-container">
+            <Link href="https://arbeidssokerregistrering.nav.no/" passHref>
+              <Button variant="primary" as="a">
+                {getAppText("arbeidssoker.registrer-som-arbeidssoker-knapp")}
+              </Button>
+            </Link>
+            <Link href={`https://www.nav.no/no/ditt-nav`} passHref>
+              <Button variant="secondary">{getAppText("arbeidssoker.avbryt-knapp")}</Button>
+            </Link>
+          </div>
+        </>
+      )}
+      {arbeidssokerStatus === "UNKNOWN" && (
+        <>
+          <Heading level="2" size="small">
+            {getAppText("arbeidssoker.header")}
+          </Heading>
+          <Alert variant="warning" className={styles.arbeidssokerStatusErrorWarning}>
+            {getAppText("arbeidssoker.arbeidssoker-status.varsel-tekst")}
+          </Alert>
+          <div className="navigation-container">
+            <Link href="/" passHref>
+              <Button variant="primary" as="a">
+                {getAppText("arbeidssoker.sok-dagpenger.knapp")}
+              </Button>
+            </Link>
+            <Link href={`https://www.nav.no/no/ditt-nav`} passHref>
+              <Button variant="secondary">{getAppText("arbeidssoker.avbryt-knapp")}</Button>
+            </Link>
+          </div>
+        </>
+      )}
+      {hasDeleteSoknadError && <ErrorRetryModal errorType={ErrorTypesEnum.GenericError} />}
     </>
   );
 }


### PR DESCRIPTION
- Vise sist endret dato default, opprettet dato som fallback
- Flyttet sletting og redirect logikken fra `/inngang` til `/arbeidssoker` isteden
- Vise varsel tekst dersom henting av arbeidssøkers status feilet (`UNKOWN`)

<img width="415" alt="Screenshot 2022-10-26 at 13 42 49" src="https://user-images.githubusercontent.com/110396878/198017474-209fcbd4-448c-4a46-88c6-92e2b0c9e7dc.png">
