### PR TITLE
DAG-546: Disable scrolling for input type Number

### DIFF
--- a/src/components/faktum/FaktumNumber.tsx
+++ b/src/components/faktum/FaktumNumber.tsx
@@ -137,6 +137,7 @@ export function FaktumNumber(props: IFaktum<IQuizNumberFaktum>) {
         step={faktum.type === "double" ? "0.1" : "1"}
         size="medium"
         type="number"
+        onWheel={() => (document.activeElement as HTMLElement).blur()}
         onChange={onValueChange}
         onBlur={debouncedChange.flush}
         error={getValidationMessage()}


### PR DESCRIPTION
Første forslag som ikke fungerer helt `<input type="text" inputmode="numeric" pattern="[0-9]*">`. Med det får man lov å skrive inn bokstaver, det vil vi kanskje ikke?
Tråd på slack: https://nav-it.slack.com/archives/C7NE7A8UF/p1667203911279829


Dette kodesnuttet bare disable scrolling innen input feltet. Ikke helt sikker på om UU eksterter liker denne løsningen. Men det kan vi ta det opp når vi skal ha neste møte med de.

