### PR TITLE
Fjernet paralell bundling av filer til vi har kontroll på "dirty upda…

### DIFF
--- a/src/hooks/dokumentkrav/useDokumentkravBundler.ts
+++ b/src/hooks/dokumentkrav/useDokumentkravBundler.ts
@@ -33,20 +33,18 @@ export function useDokumentkravBundler(): IUseDokumentkravBundler {
 
     setIsBundling(true);
 
-    await Promise.all(
-      dokumentkravToBundle.map(async (dokumentkrav) => {
-        if (dokumentkrav.svar === DOKUMENTKRAV_SVAR_SEND_NAA && dokumentkrav.filer.length > 0) {
-          try {
-            const response = await bundleDokumentkravFiles(uuid as string, dokumentkrav);
-            if (!response.ok) {
-              throw Error(response.statusText);
-            }
-          } catch {
-            tempErrorList.push(dokumentkrav);
+    for (const dokumentkrav of dokumentkravToBundle) {
+      if (dokumentkrav.svar === DOKUMENTKRAV_SVAR_SEND_NAA && dokumentkrav.filer.length > 0) {
+        try {
+          const response = await bundleDokumentkravFiles(uuid as string, dokumentkrav);
+          if (!response.ok) {
+            throw Error(response.statusText);
           }
+        } catch {
+          tempErrorList.push(dokumentkrav);
         }
-      })
-    );
+      }
+    }
 
     setIsBundling(false);
 


### PR DESCRIPTION
…tes" på backend.

DAG-611


Startet med å spleise `useEttersending()` og `useDokumentkravBundler()` men der kommer kunnskapen min til kort. Endte med å bare fjerne awaitALL promise  