### PR TITLE
DAG-656: Ettersending vises nå alltid innen 12 uker selv om alle dokumentkrav er lastet opp

### DIFF
--- a/src/components/receipt-documents-missing/ReceiptDocumentsMissing.tsx
+++ b/src/components/receipt-documents-missing/ReceiptDocumentsMissing.tsx
@@ -1,10 +1,7 @@
-import { Button, Heading, Tag } from "@navikt/ds-react";
-import Link from "next/link";
+import { Heading, Tag } from "@navikt/ds-react";
 import { useSanity } from "../../context/sanity-context";
-import { useUuid } from "../../hooks/useUuid";
 import {
   KVITTERING_MANGLER_DOKUMENT_ANTALL_MANGLER,
-  KVITTERING_MANGLER_DOKUMENT_GO_TIL_OPPLASTING_KNAPP,
   KVITTERING_MANGLER_DOKUMENT_HEADING,
 } from "../../text-constants";
 import { IDokumentkrav } from "../../types/documentation.types";
@@ -17,7 +14,6 @@ interface IProps {
 
 export function ReceiptDocumentsMissing(props: IProps) {
   const { getAppText } = useSanity();
-  const { uuid } = useUuid();
 
   return (
     <div>
@@ -33,10 +29,6 @@ export function ReceiptDocumentsMissing(props: IProps) {
       {props.documents.map((dokumentkrav) => (
         <ReceiptDocumentsMissingItem key={dokumentkrav.beskrivendeId} {...dokumentkrav} />
       ))}
-
-      <Link href={`/${uuid}/ettersending`} passHref>
-        <Button as="a">{getAppText(KVITTERING_MANGLER_DOKUMENT_GO_TIL_OPPLASTING_KNAPP)}</Button>
-      </Link>
     </div>
   );
 }

--- a/src/components/receipt-upload-documents/ReceiptUploadDocuments.module.css
+++ b/src/components/receipt-upload-documents/ReceiptUploadDocuments.module.css
@@ -1,0 +1,3 @@
+.goToInnsending {
+  margin-top: var(--navds-spacing-4);
+}

--- a/src/components/receipt-upload-documents/ReceiptUploadDocuments.tsx
+++ b/src/components/receipt-upload-documents/ReceiptUploadDocuments.tsx
@@ -45,7 +45,7 @@ export function ReceiptUploadDocuments({ soknadStatus }: IProps) {
         <div>
           <BodyShort>{getAppText(KVITTERING_ETTERSENDING_FRIST_UTGATT_TEKST)}</BodyShort>
 
-          <Link href={`/${uuid}/innsending`} passHref>
+          <Link href={`/generell-innsending`} passHref>
             <Button as="a" className={styles.goToInnsending}>
               {getAppText(KVITTERING_ETTERSENDING_FRIST_UTGATT_LENKE)}
             </Button>

--- a/src/components/receipt-upload-documents/ReceiptUploadDocuments.tsx
+++ b/src/components/receipt-upload-documents/ReceiptUploadDocuments.tsx
@@ -36,7 +36,7 @@ export function ReceiptUploadDocuments({ soknadStatus }: IProps) {
   return (
     <>
       {canUploadDocuments && (
-        <Link href={`/${uuid}/ettersending`} passHref>
+        <Link href={`/soknad/${uuid}/ettersending`} passHref>
           <Button as="a">{getAppText(KVITTERING_MANGLER_DOKUMENT_GO_TIL_OPPLASTING_KNAPP)}</Button>
         </Link>
       )}

--- a/src/components/receipt-upload-documents/ReceiptUploadDocuments.tsx
+++ b/src/components/receipt-upload-documents/ReceiptUploadDocuments.tsx
@@ -1,0 +1,57 @@
+import { BodyShort, Button } from "@navikt/ds-react";
+import { addWeeks, isBefore } from "date-fns";
+import Link from "next/link";
+import React from "react";
+import { useSanity } from "../../context/sanity-context";
+import { useUuid } from "../../hooks/useUuid";
+import { ISoknadStatus } from "../../pages/api/soknad/[uuid]/status";
+import {
+  KVITTERING_ETTERSENDING_FRIST_UTGATT_LENKE,
+  KVITTERING_ETTERSENDING_FRIST_UTGATT_TEKST,
+  KVITTERING_MANGLER_DOKUMENT_GO_TIL_OPPLASTING_KNAPP,
+} from "../../text-constants";
+import styles from "./ReceiptUploadDocuments.module.css";
+
+interface IProps {
+  soknadStatus: ISoknadStatus;
+}
+
+export function ReceiptUploadDocuments({ soknadStatus }: IProps) {
+  const { getAppText } = useSanity();
+  const { uuid } = useUuid();
+
+  function within12Weeks() {
+    if (!soknadStatus.innsendt) {
+      return false;
+    }
+
+    const innsendtDate = new Date(soknadStatus.innsendt);
+    const today = new Date();
+    const endDate = addWeeks(innsendtDate, 12);
+    return isBefore(today, endDate);
+  }
+
+  const canUploadDocuments = within12Weeks();
+
+  return (
+    <>
+      {canUploadDocuments && (
+        <Link href={`/${uuid}/ettersending`} passHref>
+          <Button as="a">{getAppText(KVITTERING_MANGLER_DOKUMENT_GO_TIL_OPPLASTING_KNAPP)}</Button>
+        </Link>
+      )}
+
+      {!canUploadDocuments && (
+        <div>
+          <BodyShort>{getAppText(KVITTERING_ETTERSENDING_FRIST_UTGATT_TEKST)}</BodyShort>
+
+          <Link href={`/${uuid}/innsending`} passHref>
+            <Button as="a" className={styles.goToInnsending}>
+              {getAppText(KVITTERING_ETTERSENDING_FRIST_UTGATT_LENKE)}
+            </Button>
+          </Link>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/text-constants.ts
+++ b/src/text-constants.ts
@@ -17,8 +17,8 @@ export const KVITTERING_MANGLER_DOKUMENT_HEADING = "kvittering.heading.mangler-d
 export const KVITTERING_MANGLER_DOKUMENT_ANTALL_MANGLER = "kvittering.tekst.antall-mangler";
 export const KVITTERING_MANGLER_DOKUMENT_GO_TIL_OPPLASTING_KNAPP = "kvittering.mangler-dokumenter.go-til-opplasting-knapp";
 
-export const KVITTERING_ETTERSENDING_FRIST_UTGATT_TEKST = "kvittering.ettersending.frist-utgatt.tekst";
-export const KVITTERING_ETTERSENDING_FRIST_UTGATT_LENKE = "kvittering.ettersending.frist-utgatt.lenke";
+export const KVITTERING_ETTERSENDING_FRIST_UTGATT_TEKST = "kvittering.ettersending.tekst.frist-utgatt";
+export const KVITTERING_ETTERSENDING_FRIST_UTGATT_LENKE = "kvittering.ettersending.lenke.frist-utgatt";
 
 export const KVITTERING_TEKST_SENDT_AV_DEG = "kvittering.tekst.sendt-av-deg";
 

--- a/src/text-constants.ts
+++ b/src/text-constants.ts
@@ -17,6 +17,9 @@ export const KVITTERING_MANGLER_DOKUMENT_HEADING = "kvittering.heading.mangler-d
 export const KVITTERING_MANGLER_DOKUMENT_ANTALL_MANGLER = "kvittering.tekst.antall-mangler";
 export const KVITTERING_MANGLER_DOKUMENT_GO_TIL_OPPLASTING_KNAPP = "kvittering.mangler-dokumenter.go-til-opplasting-knapp";
 
+export const KVITTERING_ETTERSENDING_FRIST_UTGATT_TEKST = "kvittering.ettersending.frist-utgatt.tekst";
+export const KVITTERING_ETTERSENDING_FRIST_UTGATT_LENKE = "kvittering.ettersending.frist-utgatt.lenke";
+
 export const KVITTERING_TEKST_SENDT_AV_DEG = "kvittering.tekst.sendt-av-deg";
 
 export const ETTERSENDING_TITTEL = "ettersending.tittel";

--- a/src/views/receipt/Receipt.tsx
+++ b/src/views/receipt/Receipt.tsx
@@ -23,6 +23,7 @@ import styles from "./Receipts.module.css";
 import { PageMeta } from "../../components/PageMeta";
 import { PortableText } from "@portabletext/react";
 import { SoknadHeader } from "../../components/soknad-header/SoknadHeader";
+import { ReceiptUploadDocuments } from "../../components/receipt-upload-documents/ReceiptUploadDocuments";
 
 interface IProps {
   soknadStatus: ISoknadStatus;
@@ -52,7 +53,7 @@ export function Receipt(props: IProps) {
   );
 
   function navigateToMineDagpener() {
-    window.location.assign("https://arbeid.dev.nav.no/arbeid/dagpenger/mine-dagpenger");
+    window.location.assign("https://www.nav.no/arbeid/dagpenger/mine-dagpenger");
   }
 
   return (
@@ -73,6 +74,7 @@ export function Receipt(props: IProps) {
 
       <div className={styles.documentList}>
         {missingDocuments.length > 0 && <ReceiptDocumentsMissing documents={missingDocuments} />}
+        <ReceiptUploadDocuments soknadStatus={props.soknadStatus} />
         {uploadedDocuments.length > 0 && <ReceiptDocumentsUploaded documents={uploadedDocuments} />}
         {notSendingDocuments.length > 0 && (
           <ReceiptDocumentsNotSending documents={notSendingDocuments} />


### PR DESCRIPTION
Viser alltid ettersending på kvittering innen 12 uker. Etterpå viser vi lenke til generell innsending.

Slik ser det ut nå hvis det er innenfor 12 uker:
<img width="695" alt="image" src="https://user-images.githubusercontent.com/3233286/201909509-b2174e85-ab7a-437a-937f-a5738489e2d3.png">

Slik ser det ut etter 12 uker (tekster mangler ennå):
<img width="708" alt="image" src="https://user-images.githubusercontent.com/3233286/201909613-88c0233c-75b4-41ed-b339-6bb355e86879.png">
