### PR TITLE
Kvittering - Fjerner overskriving av soknadStatus hvis søknaden mangler dokumenter

### DIFF
--- a/src/pages/soknad/[uuid]/kvittering.tsx
+++ b/src/pages/soknad/[uuid]/kvittering.tsx
@@ -104,7 +104,7 @@ export async function getServerSideProps(
   );
 
   if (missingDocuments && missingDocuments.length > 0) {
-    soknadStatus = { status: "ManglerDokumenter" };
+    soknadStatus.status = "ManglerDokumenter";
   }
 
   if (arbeidssokerStatusResponse.ok) {


### PR DESCRIPTION
Vi trenger å vite innsendt dato for å vite m vi skal vise knapp til ettersending eller ikke. Vi overskrev før hele status-objektet hvis vi hadde manglende dokumenter, slik at innsendt dato ble nullet ut. Omgjør dette slik at vi nå kun setter status.