### PR TITLE
Legger til flere tester, defaulter til beskrivendeId på seksjonstittel

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -14,6 +14,7 @@ jest.mock("next/router", () => {
       query: {
         uuid: "localhost-uuid",
       },
+      push: jest.fn(),
     }),
   };
 });

--- a/src/__mocks__/SetupContext.tsx
+++ b/src/__mocks__/SetupContext.tsx
@@ -1,0 +1,43 @@
+import React, { PropsWithChildren } from "react";
+import { DokumentkravProvider } from "../context/dokumentkrav-context";
+import { QuizProvider } from "../context/quiz-context";
+import { SanityProvider } from "../context/sanity-context";
+import { ValidationProvider } from "../context/validation-context";
+import { IDokumentkrav, IDokumentkravList } from "../types/documentation.types";
+import { IQuizSeksjon, IQuizState } from "../types/quiz.types";
+import { sanityMocks } from "./sanity.mocks";
+
+interface IProps {
+  dokumentkrav?: IDokumentkrav[];
+  soknadState?: IQuizState;
+  quizSeksjoner?: IQuizSeksjon[];
+}
+
+export const mockSoknadState: IQuizState = {
+  ferdig: false,
+  antallSeksjoner: 11,
+  seksjoner: [],
+  versjon_navn: "Dagpenger",
+  roller: [],
+};
+
+const mockDokumentkravList: IDokumentkravList = {
+  soknad_uuid: "12345",
+  krav: [],
+};
+
+export function SetupContext(props: PropsWithChildren<IProps>) {
+  const { children, dokumentkrav = [], quizSeksjoner = [], soknadState = mockSoknadState } = props;
+
+  return (
+    <div id="__next">
+      <SanityProvider initialState={sanityMocks}>
+        <QuizProvider initialState={{ ...soknadState, seksjoner: quizSeksjoner }}>
+          <DokumentkravProvider initialState={{ ...mockDokumentkravList, krav: dokumentkrav }}>
+            <ValidationProvider>{children}</ValidationProvider>
+          </DokumentkravProvider>
+        </QuizProvider>
+      </SanityProvider>
+    </div>
+  );
+}

--- a/src/components/dokumentkrav/Dokumentkrav.test.tsx
+++ b/src/components/dokumentkrav/Dokumentkrav.test.tsx
@@ -8,18 +8,17 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Dokumentkrav } from "./Dokumentkrav";
-import { SanityProvider } from "../../context/sanity-context";
 import { DOKUMENTKRAV_SVAR_SEND_NAA } from "../../constants";
-import { sanityMocks } from "../../__mocks__/sanity.mocks";
 import { mockDokumentkravList } from "../../localhost-data/dokumentkrav-list";
 import fetch from "jest-fetch-mock";
+import { SetupContext } from "../../__mocks__/SetupContext";
 
 describe("Dokumentkrav", () => {
   test("Should show dokumentkrav title", async () => {
     render(
-      <SanityProvider initialState={sanityMocks}>
+      <SetupContext>
         <Dokumentkrav dokumentkrav={mockDokumentkravList.krav[0]} onChange={() => ""} />
-      </SanityProvider>
+      </SetupContext>
     );
 
     await waitFor(() => {
@@ -31,9 +30,9 @@ describe("Dokumentkrav", () => {
 
   test("Should show dokumentkrav title and employer name for arbeidsforhold dokumentkrav", async () => {
     render(
-      <SanityProvider initialState={sanityMocks}>
+      <SetupContext>
         <Dokumentkrav dokumentkrav={mockDokumentkravList.krav[0]} onChange={() => ""} />
-      </SanityProvider>
+      </SetupContext>
     );
 
     await waitFor(() => {
@@ -46,9 +45,9 @@ describe("Dokumentkrav", () => {
     const user = userEvent.setup();
 
     render(
-      <SanityProvider initialState={sanityMocks}>
+      <SetupContext>
         <Dokumentkrav dokumentkrav={mockDokumentkravList.krav[0]} onChange={() => ""} />
-      </SanityProvider>
+      </SetupContext>
     );
 
     await user.click(screen.getByLabelText(DOKUMENTKRAV_SVAR_SEND_NAA));
@@ -62,9 +61,9 @@ describe("Dokumentkrav", () => {
     const user = userEvent.setup();
 
     render(
-      <SanityProvider initialState={sanityMocks}>
+      <SetupContext>
         <Dokumentkrav dokumentkrav={mockDokumentkravList.krav[0]} onChange={() => ""} />
-      </SanityProvider>
+      </SetupContext>
     );
 
     await user.click(screen.getByLabelText(DOKUMENTKRAV_SVAR_SEND_NAA));
@@ -79,9 +78,9 @@ describe("Dokumentkrav", () => {
     const user = userEvent.setup();
 
     render(
-      <SanityProvider initialState={sanityMocks}>
+      <SetupContext>
         <Dokumentkrav dokumentkrav={mockDokumentkravList.krav[0]} onChange={() => ""} />
-      </SanityProvider>
+      </SetupContext>
     );
 
     await user.click(screen.getByLabelText("dokumentkrav.svar.sender.ikke"));
@@ -138,9 +137,9 @@ describe("Dokumentkrav", () => {
         const user = userEvent.setup();
 
         render(
-          <SanityProvider initialState={sanityMocks}>
+          <SetupContext>
             <Dokumentkrav dokumentkrav={mockDokumentkravList.krav[0]} onChange={() => ""} />
-          </SanityProvider>
+          </SetupContext>
         );
 
         const file = new File(["file"], "image.jpg", {
@@ -163,9 +162,9 @@ describe("Dokumentkrav", () => {
       const user = userEvent.setup();
 
       render(
-        <SanityProvider initialState={sanityMocks}>
+        <SetupContext>
           <Dokumentkrav dokumentkrav={mockDokumentkravList.krav[0]} onChange={() => ""} />
-        </SanityProvider>
+        </SetupContext>
       );
 
       const file = new File(["file"], "image.json", {
@@ -180,7 +179,6 @@ describe("Dokumentkrav", () => {
       expect(
         await screen.findByText("filopplaster.feilmelding.format-storrelse-beskrivelse")
       ).toBeInTheDocument();
-
       expect(fetch.mock.calls.length).toEqual(0);
     });
   });
@@ -206,9 +204,9 @@ describe("Dokumentkrav", () => {
       const user = userEvent.setup();
 
       render(
-        <SanityProvider initialState={sanityMocks}>
+        <SetupContext>
           <Dokumentkrav dokumentkrav={mockDokumentkravList.krav[0]} onChange={() => ""} />
-        </SanityProvider>
+        </SetupContext>
       );
 
       expect(await screen.findByText(fileToTest.filnavn)).toBeInTheDocument();

--- a/src/components/faktum/Faktum.test.tsx
+++ b/src/components/faktum/Faktum.test.tsx
@@ -1,13 +1,10 @@
 import React from "react";
 import { render, waitFor, screen } from "@testing-library/react";
 import { Faktum } from "./Faktum";
-import { SanityProvider } from "../../context/sanity-context";
-import { IQuizGeneratorFaktum, IQuizSeksjon, IQuizState, QuizFaktum } from "../../types/quiz.types";
-import { QuizProvider } from "../../context/quiz-context";
-import { sanityMocks } from "../../__mocks__/sanity.mocks";
-import { ValidationProvider } from "../../context/validation-context";
+import { IQuizGeneratorFaktum, IQuizSeksjon, QuizFaktum } from "../../types/quiz.types";
+import { SetupContext } from "../../__mocks__/SetupContext";
 
-const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
+const faktumMockData: QuizFaktum = {
   id: "10001",
   svar: "faktum.mottatt-dagpenger-siste-12-mnd.svar.nei",
   type: "envalg",
@@ -37,30 +34,18 @@ const dokumentasjonskravMockdata: QuizFaktum[] | IQuizGeneratorFaktum[] = [
   },
 ];
 
-const sectionStateMockData: IQuizSeksjon = {
+const sectionMockdata: IQuizSeksjon = {
   fakta: [faktumMockData],
   beskrivendeId: "din-situasjon",
   ferdig: true,
 };
 
-const mockSoknadState: IQuizState = {
-  ferdig: false,
-  antallSeksjoner: 11,
-  seksjoner: [sectionStateMockData],
-  versjon_navn: "Dagpenger",
-  roller: [],
-};
-
 describe("Faktum", () => {
   test("Should show faktum question and answers", async () => {
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={mockSoknadState}>
-          <ValidationProvider>
-            <Faktum faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockdata]}>
+        <Faktum faktum={faktumMockData} />
+      </SetupContext>
     );
 
     await waitFor(() => {
@@ -74,15 +59,9 @@ describe("Faktum", () => {
 
   test("Should show faktum dokumentation info if that's triggered by the answer", async () => {
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={mockSoknadState}>
-          <ValidationProvider>
-            <Faktum
-              faktum={{ ...faktumMockData, sannsynliggjoresAv: dokumentasjonskravMockdata }}
-            />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockdata]}>
+        <Faktum faktum={{ ...faktumMockData, sannsynliggjoresAv: dokumentasjonskravMockdata }} />
+      </SetupContext>
     );
 
     const dokumentationTitle = dokumentasjonskravMockdata[0].beskrivendeId;

--- a/src/components/faktum/FaktumBoolean.test.tsx
+++ b/src/components/faktum/FaktumBoolean.test.tsx
@@ -1,16 +1,11 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { booleanToTextId, FaktumBoolean, textIdToBoolean } from "./FaktumBoolean";
-import { SanityProvider } from "../../context/sanity-context";
-import { IQuizGeneratorFaktum, IQuizSeksjon, IQuizState, QuizFaktum } from "../../types/quiz.types";
-import { QuizProvider } from "../../context/quiz-context";
+import { IQuizGeneratorFaktum, IQuizSeksjon, QuizFaktum } from "../../types/quiz.types";
 import userEvent from "@testing-library/user-event";
-import { sanityMocks } from "../../__mocks__/sanity.mocks";
-import { ValidationProvider } from "../../context/validation-context";
 
 import * as SentryLogger from "../../sentry.logger";
-
-//jest.mock("../../sentry.logger");
+import { SetupContext } from "../../__mocks__/SetupContext";
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
   id: "8007.1",
@@ -30,25 +25,15 @@ const sectionMockData: IQuizSeksjon = {
   ferdig: true,
 };
 
-const soknadStateMockData: IQuizState = {
-  ferdig: false,
-  antallSeksjoner: 11,
-  seksjoner: [sectionMockData],
-};
-
 describe("FaktumBoolean", () => {
   // Undo any answer after each test
   beforeEach(() => (faktumMockData.svar = undefined));
 
   test("Should show faktum question and answers", async () => {
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumBoolean faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumBoolean faktum={faktumMockData} />
+      </SetupContext>
     );
     await waitFor(() => {
       expect(screen.queryByText(faktumMockData.beskrivendeId)).toBeInTheDocument();
@@ -61,13 +46,9 @@ describe("FaktumBoolean", () => {
     faktumMockData.svar = true;
 
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumBoolean faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumBoolean faktum={faktumMockData} />
+      </SetupContext>
     );
 
     // Casting it to access the value attribute
@@ -86,13 +67,9 @@ describe("FaktumBoolean", () => {
     faktumMockData.readOnly = true;
 
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumBoolean faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumBoolean faktum={faktumMockData} />
+      </SetupContext>
     );
 
     expect(spy).not.toHaveBeenCalledWith("");
@@ -106,13 +83,9 @@ describe("FaktumBoolean", () => {
       const onchange = jest.fn();
 
       render(
-        <SanityProvider initialState={sanityMocks}>
-          <QuizProvider initialState={soknadStateMockData}>
-            <ValidationProvider>
-              <FaktumBoolean faktum={faktumMockData} onChange={onchange} />
-            </ValidationProvider>
-          </QuizProvider>
-        </SanityProvider>
+        <SetupContext quizSeksjoner={[sectionMockData]}>
+          <FaktumBoolean faktum={faktumMockData} onChange={onchange} />
+        </SetupContext>
       );
 
       const radioToClick = screen.getByLabelText(svar);

--- a/src/components/faktum/FaktumDato.test.tsx
+++ b/src/components/faktum/FaktumDato.test.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import { render, waitFor, screen } from "@testing-library/react";
 import { FaktumDato } from "./FaktumDato";
-import { SanityProvider } from "../../context/sanity-context";
-import { IQuizGeneratorFaktum, IQuizSeksjon, IQuizState, QuizFaktum } from "../../types/quiz.types";
-import { QuizProvider } from "../../context/quiz-context";
+import { IQuizGeneratorFaktum, IQuizSeksjon, QuizFaktum } from "../../types/quiz.types";
 import userEvent from "@testing-library/user-event";
-import { sanityMocks } from "../../__mocks__/sanity.mocks";
-import { ValidationProvider } from "../../context/validation-context";
+import { SetupContext } from "../../__mocks__/SetupContext";
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
   id: "8001",
@@ -22,25 +19,15 @@ const sectionMockData: IQuizSeksjon = {
   ferdig: true,
 };
 
-const soknadStateMockData: IQuizState = {
-  ferdig: false,
-  antallSeksjoner: 11,
-  seksjoner: [sectionMockData],
-};
-
 describe("FaktumDato", () => {
   // Undo any answer after each test
   beforeEach(() => (faktumMockData.svar = undefined));
 
   test("Should show faktum question and datepicker", async () => {
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumDato faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumDato faktum={faktumMockData} />
+      </SetupContext>
     );
 
     const datepicker = screen.getByLabelText(faktumMockData.beskrivendeId);
@@ -56,13 +43,9 @@ describe("FaktumDato", () => {
     faktumMockData.svar = svar;
 
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumDato faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumDato faktum={faktumMockData} />
+      </SetupContext>
     );
 
     // Casting it to access the value attribute
@@ -80,13 +63,9 @@ describe("FaktumDato", () => {
       const onchange = jest.fn();
 
       render(
-        <SanityProvider initialState={sanityMocks}>
-          <QuizProvider initialState={soknadStateMockData}>
-            <ValidationProvider>
-              <FaktumDato faktum={faktumMockData} onChange={onchange} />
-            </ValidationProvider>
-          </QuizProvider>
-        </SanityProvider>
+        <SetupContext quizSeksjoner={[sectionMockData]}>
+          <FaktumDato faktum={faktumMockData} onChange={onchange} />
+        </SetupContext>
       );
 
       const datepicker = screen.getByLabelText(faktumMockData.beskrivendeId) as HTMLInputElement;

--- a/src/components/faktum/FaktumEnvalg.test.tsx
+++ b/src/components/faktum/FaktumEnvalg.test.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import { render, waitFor, screen } from "@testing-library/react";
 import { FaktumEnvalg } from "./FaktumEnvalg";
-import { SanityProvider } from "../../context/sanity-context";
-import { IQuizGeneratorFaktum, IQuizSeksjon, IQuizState, QuizFaktum } from "../../types/quiz.types";
-import { QuizProvider } from "../../context/quiz-context";
+import { IQuizGeneratorFaktum, IQuizSeksjon, QuizFaktum } from "../../types/quiz.types";
 import userEvent from "@testing-library/user-event";
-import { sanityMocks } from "../../__mocks__/sanity.mocks";
-import { ValidationProvider } from "../../context/validation-context";
+import { SetupContext } from "../../__mocks__/SetupContext";
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
   id: "10001",
@@ -28,25 +25,15 @@ const sectionMockData: IQuizSeksjon = {
   ferdig: true,
 };
 
-const soknadStateMockData: IQuizState = {
-  ferdig: false,
-  antallSeksjoner: 11,
-  seksjoner: [sectionMockData],
-};
-
 describe("FaktumEnvalg", () => {
   // Undo any answer after each test
   beforeEach(() => (faktumMockData.svar = undefined));
 
   test("Should show faktum question and answers", async () => {
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumEnvalg faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumEnvalg faktum={faktumMockData} />
+      </SetupContext>
     );
 
     await waitFor(() => {
@@ -62,13 +49,9 @@ describe("FaktumEnvalg", () => {
     faktumMockData.svar = svar;
 
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumEnvalg faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumEnvalg faktum={faktumMockData} />
+      </SetupContext>
     );
 
     // Casting it to access the value attribute
@@ -86,13 +69,9 @@ describe("FaktumEnvalg", () => {
       const onchange = jest.fn();
 
       render(
-        <SanityProvider initialState={sanityMocks}>
-          <QuizProvider initialState={soknadStateMockData}>
-            <ValidationProvider>
-              <FaktumEnvalg faktum={faktumMockData} onChange={onchange} />
-            </ValidationProvider>
-          </QuizProvider>
-        </SanityProvider>
+        <SetupContext quizSeksjoner={[sectionMockData]}>
+          <FaktumEnvalg faktum={faktumMockData} onChange={onchange} />
+        </SetupContext>
       );
 
       const firstRadio = screen.getByLabelText(svar);

--- a/src/components/faktum/FaktumFlervalg.test.tsx
+++ b/src/components/faktum/FaktumFlervalg.test.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import { render, waitFor, screen } from "@testing-library/react";
 import { FaktumFlervalg } from "./FaktumFlervalg";
-import { SanityProvider } from "../../context/sanity-context";
-import { IQuizGeneratorFaktum, IQuizSeksjon, IQuizState, QuizFaktum } from "../../types/quiz.types";
-import { QuizProvider } from "../../context/quiz-context";
+import { IQuizGeneratorFaktum, IQuizSeksjon, QuizFaktum } from "../../types/quiz.types";
 import userEvent from "@testing-library/user-event";
-import { sanityMocks } from "../../__mocks__/sanity.mocks";
-import { ValidationProvider } from "../../context/validation-context";
+import { SetupContext } from "../../__mocks__/SetupContext";
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
   id: "3008",
@@ -28,25 +25,15 @@ const sectionMockData: IQuizSeksjon = {
   ferdig: true,
 };
 
-const soknadStateMockData: IQuizState = {
-  ferdig: false,
-  antallSeksjoner: 11,
-  seksjoner: [sectionMockData],
-};
-
 describe("FaktumFlervalg", () => {
   // Undo any answer after each test
   beforeEach(() => (faktumMockData.svar = undefined));
 
   test("Should show faktum question and answers", async () => {
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumFlervalg faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumFlervalg faktum={faktumMockData} />
+      </SetupContext>
     );
 
     await waitFor(() => {
@@ -65,13 +52,9 @@ describe("FaktumFlervalg", () => {
     faktumMockData.svar = svar;
 
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumFlervalg faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumFlervalg faktum={faktumMockData} />
+      </SetupContext>
     );
 
     // Casting it to access the value attribute
@@ -90,13 +73,9 @@ describe("FaktumFlervalg", () => {
       const onchange = jest.fn();
 
       render(
-        <SanityProvider initialState={sanityMocks}>
-          <QuizProvider initialState={soknadStateMockData}>
-            <ValidationProvider>
-              <FaktumFlervalg faktum={faktumMockData} onChange={onchange} />
-            </ValidationProvider>
-          </QuizProvider>
-        </SanityProvider>
+        <SetupContext quizSeksjoner={[sectionMockData]}>
+          <FaktumFlervalg faktum={faktumMockData} onChange={onchange} />
+        </SetupContext>
       );
 
       const svarCheckbox = screen.getByLabelText(svar[0]);
@@ -115,13 +94,9 @@ describe("FaktumFlervalg", () => {
       const onchange = jest.fn();
 
       render(
-        <SanityProvider initialState={sanityMocks}>
-          <QuizProvider initialState={soknadStateMockData}>
-            <ValidationProvider>
-              <FaktumFlervalg faktum={faktumMockData} onChange={onchange} />
-            </ValidationProvider>
-          </QuizProvider>
-        </SanityProvider>
+        <SetupContext quizSeksjoner={[sectionMockData]}>
+          <FaktumFlervalg faktum={faktumMockData} onChange={onchange} />
+        </SetupContext>
       );
 
       const svar1Checkbox = screen.getByLabelText(svar[0]);

--- a/src/components/faktum/FaktumLand.test.tsx
+++ b/src/components/faktum/FaktumLand.test.tsx
@@ -1,13 +1,10 @@
 import React from "react";
 import { render, waitFor, screen } from "@testing-library/react";
 import { FaktumLand } from "./FaktumLand";
-import { SanityProvider } from "../../context/sanity-context";
-import { IQuizGeneratorFaktum, IQuizSeksjon, IQuizState, QuizFaktum } from "../../types/quiz.types";
-import { QuizProvider } from "../../context/quiz-context";
+import { IQuizGeneratorFaktum, IQuizSeksjon, QuizFaktum } from "../../types/quiz.types";
 import userEvent from "@testing-library/user-event";
-import { sanityMocks } from "../../__mocks__/sanity.mocks";
 import { getCountryName } from "../../country.utils";
-import { ValidationProvider } from "../../context/validation-context";
+import { SetupContext } from "../../__mocks__/SetupContext";
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
   id: "6001",
@@ -76,25 +73,15 @@ const sectionMockData: IQuizSeksjon = {
   ferdig: true,
 };
 
-const soknadStateMockData: IQuizState = {
-  ferdig: false,
-  antallSeksjoner: 11,
-  seksjoner: [sectionMockData],
-};
-
 describe("FaktumLand", () => {
   // Undo any answer after each test
   beforeEach(() => (faktumMockData.svar = undefined));
 
   test("Should show faktum question and answers", async () => {
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumLand faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumLand faktum={faktumMockData} />
+      </SetupContext>
     );
 
     const option1 = getCountryName(faktumMockData.gyldigeLand[0], "no");
@@ -114,13 +101,9 @@ describe("FaktumLand", () => {
     faktumMockData.svar = svar;
 
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumLand faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumLand faktum={faktumMockData} />
+      </SetupContext>
     );
 
     // Casting it to access the value attribute
@@ -140,13 +123,9 @@ describe("FaktumLand", () => {
       const onchange = jest.fn();
 
       render(
-        <SanityProvider initialState={sanityMocks}>
-          <QuizProvider initialState={soknadStateMockData}>
-            <ValidationProvider>
-              <FaktumLand faktum={faktumMockData} onChange={onchange} />
-            </ValidationProvider>
-          </QuizProvider>
-        </SanityProvider>
+        <SetupContext quizSeksjoner={[sectionMockData]}>
+          <FaktumLand faktum={faktumMockData} onChange={onchange} />
+        </SetupContext>
       );
 
       const selectedOptionText = getCountryName(svar, "no");
@@ -166,21 +145,14 @@ describe("FaktumLand", () => {
       const onchange = jest.fn();
 
       render(
-        <SanityProvider initialState={sanityMocks}>
-          <QuizProvider initialState={soknadStateMockData}>
-            <ValidationProvider>
-              <FaktumLand faktum={faktumMockDataBostedsland} onChange={onchange} />
-            </ValidationProvider>
-          </QuizProvider>
-        </SanityProvider>
+        <SetupContext quizSeksjoner={[sectionMockData]}>
+          <FaktumLand faktum={faktumMockDataBostedsland} onChange={onchange} />
+        </SetupContext>
       );
 
       await waitFor(() => {
         const selectedOption = screen.getByRole("option", { selected: true }) as HTMLInputElement;
         expect(selectedOption.value).toEqual(svar);
-      });
-
-      await waitFor(() => {
         expect(onchange).toBeCalledTimes(1);
         expect(onchange).toBeCalledWith(faktumMockDataBostedsland, svar);
       });

--- a/src/components/faktum/FaktumNumber.test.tsx
+++ b/src/components/faktum/FaktumNumber.test.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import { render, waitFor, screen } from "@testing-library/react";
 import { FaktumNumber } from "./FaktumNumber";
-import { SanityProvider } from "../../context/sanity-context";
-import { IQuizGeneratorFaktum, IQuizSeksjon, IQuizState, QuizFaktum } from "../../types/quiz.types";
-import { QuizProvider } from "../../context/quiz-context";
+import { IQuizGeneratorFaktum, IQuizSeksjon, QuizFaktum } from "../../types/quiz.types";
 import userEvent from "@testing-library/user-event";
-import { sanityMocks } from "../../__mocks__/sanity.mocks";
-import { ValidationProvider } from "../../context/validation-context";
+import { SetupContext } from "../../__mocks__/SetupContext";
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
   beskrivendeId: "faktum.barn-inntekt",
@@ -22,25 +19,15 @@ const sectionMockData: IQuizSeksjon = {
   ferdig: true,
 };
 
-const soknadStateMockData: IQuizState = {
-  ferdig: false,
-  antallSeksjoner: 11,
-  seksjoner: [sectionMockData],
-};
-
 describe("FaktumNumber", () => {
   // Undo any answer after each test
   beforeEach(() => (faktumMockData.svar = undefined));
 
   test("Should show faktum question and answers", async () => {
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumNumber faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumNumber faktum={faktumMockData} />
+      </SetupContext>
     );
 
     await waitFor(() => {
@@ -53,13 +40,9 @@ describe("FaktumNumber", () => {
     faktumMockData.svar = svar;
 
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumNumber faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumNumber faktum={faktumMockData} />
+      </SetupContext>
     );
 
     // Casting it to access the value attribute
@@ -77,13 +60,9 @@ describe("FaktumNumber", () => {
       const onchange = jest.fn();
 
       render(
-        <SanityProvider initialState={sanityMocks}>
-          <QuizProvider initialState={soknadStateMockData}>
-            <ValidationProvider>
-              <FaktumNumber faktum={faktumMockData} onChange={onchange} />
-            </ValidationProvider>
-          </QuizProvider>
-        </SanityProvider>
+        <SetupContext quizSeksjoner={[sectionMockData]}>
+          <FaktumNumber faktum={faktumMockData} onChange={onchange} />
+        </SetupContext>
       );
 
       const textInput = screen.getByLabelText(faktumMockData.beskrivendeId) as HTMLInputElement;

--- a/src/components/faktum/FaktumPeriode.test.tsx
+++ b/src/components/faktum/FaktumPeriode.test.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import { render, waitFor, screen } from "@testing-library/react";
 import { FaktumPeriode } from "./FaktumPeriode";
-import { SanityProvider } from "../../context/sanity-context";
-import { IQuizGeneratorFaktum, IQuizSeksjon, IQuizState, QuizFaktum } from "../../types/quiz.types";
-import { QuizProvider } from "../../context/quiz-context";
+import { IQuizGeneratorFaktum, IQuizSeksjon, QuizFaktum } from "../../types/quiz.types";
 import userEvent from "@testing-library/user-event";
-import { sanityMocks } from "../../__mocks__/sanity.mocks";
-import { ValidationProvider } from "../../context/validation-context";
+import { SetupContext } from "../../__mocks__/SetupContext";
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
   id: "8001",
@@ -22,25 +19,15 @@ const sectionMockData: IQuizSeksjon = {
   ferdig: true,
 };
 
-const soknadStateMockData: IQuizState = {
-  ferdig: false,
-  antallSeksjoner: 11,
-  seksjoner: [sectionMockData],
-};
-
 describe("FaktumPeriode", () => {
   // Undo any answer after each test
   beforeEach(() => (faktumMockData.svar = undefined));
 
   test("Should show faktum question and datepicker", async () => {
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumPeriode faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumPeriode faktum={faktumMockData} />
+      </SetupContext>
     );
 
     const datepickerFom = screen.getByLabelText(faktumMockData.beskrivendeId + ".fra");
@@ -58,13 +45,9 @@ describe("FaktumPeriode", () => {
     faktumMockData.svar = svar;
 
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumPeriode faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumPeriode faktum={faktumMockData} />
+      </SetupContext>
     );
 
     // Casting it to access the value attribute
@@ -88,13 +71,9 @@ describe("FaktumPeriode", () => {
       const onchange = jest.fn();
 
       render(
-        <SanityProvider initialState={sanityMocks}>
-          <QuizProvider initialState={soknadStateMockData}>
-            <ValidationProvider>
-              <FaktumPeriode faktum={faktumMockData} onChange={onchange} />
-            </ValidationProvider>
-          </QuizProvider>
-        </SanityProvider>
+        <SetupContext quizSeksjoner={[sectionMockData]}>
+          <FaktumPeriode faktum={faktumMockData} onChange={onchange} />
+        </SetupContext>
       );
 
       const datepickerFom = screen.getByLabelText(faktumMockData.beskrivendeId + ".fra");

--- a/src/components/faktum/FaktumText.test.tsx
+++ b/src/components/faktum/FaktumText.test.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import { render, waitFor, screen } from "@testing-library/react";
 import { FaktumText } from "./FaktumText";
-import { SanityProvider } from "../../context/sanity-context";
-import { IQuizTekstFaktum, IQuizSeksjon, IQuizState } from "../../types/quiz.types";
-import { QuizProvider } from "../../context/quiz-context";
+import { IQuizTekstFaktum, IQuizSeksjon } from "../../types/quiz.types";
 import userEvent from "@testing-library/user-event";
-import { sanityMocks } from "../../__mocks__/sanity.mocks";
-import { ValidationProvider } from "../../context/validation-context";
+import { SetupContext } from "../../__mocks__/SetupContext";
 
 const faktumMockData: IQuizTekstFaktum = {
   id: "8004.1",
@@ -24,25 +21,15 @@ const sectionMockData: IQuizSeksjon = {
   ferdig: true,
 };
 
-const soknadStateMockData: IQuizState = {
-  ferdig: false,
-  antallSeksjoner: 11,
-  seksjoner: [sectionMockData],
-};
-
 describe("FaktumText", () => {
   // Undo any answer after each test
   beforeEach(() => (faktumMockData.svar = undefined));
 
   test("Should show faktum question and answers", async () => {
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumText faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumText faktum={faktumMockData} />
+      </SetupContext>
     );
 
     await waitFor(() => {
@@ -55,13 +42,9 @@ describe("FaktumText", () => {
     faktumMockData.svar = svar;
 
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={soknadStateMockData}>
-          <ValidationProvider>
-            <FaktumText faktum={faktumMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <FaktumText faktum={faktumMockData} />
+      </SetupContext>
     );
 
     // Casting it to access the value attribute
@@ -79,13 +62,9 @@ describe("FaktumText", () => {
       const onchange = jest.fn();
 
       render(
-        <SanityProvider initialState={sanityMocks}>
-          <QuizProvider initialState={soknadStateMockData}>
-            <ValidationProvider>
-              <FaktumText faktum={faktumMockData} onChange={onchange} />
-            </ValidationProvider>
-          </QuizProvider>
-        </SanityProvider>
+        <SetupContext quizSeksjoner={[sectionMockData]}>
+          <FaktumText faktum={faktumMockData} onChange={onchange} />
+        </SetupContext>
       );
 
       const textInput = screen.getByLabelText(faktumMockData.beskrivendeId) as HTMLInputElement;
@@ -96,7 +75,7 @@ describe("FaktumText", () => {
         expect(onchange).toHaveBeenCalledWith(faktumMockData, svar);
       });
     });
-    
+
     test.skip("Should show error on invalid input", async () => {
       const inValidTextLengthMock =
         "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like.";
@@ -105,13 +84,9 @@ describe("FaktumText", () => {
       const onchange = jest.fn();
 
       render(
-        <SanityProvider initialState={sanityMocks}>
-          <QuizProvider initialState={soknadStateMockData}>
-            <ValidationProvider>
-              <FaktumText faktum={faktumMockData} onChange={onchange} />
-            </ValidationProvider>
-          </QuizProvider>
-        </SanityProvider>
+        <SetupContext quizSeksjoner={[sectionMockData]}>
+          <FaktumText faktum={faktumMockData} onChange={onchange} />
+        </SetupContext>
       );
 
       const textInput = screen.getByLabelText(faktumMockData.beskrivendeId) as HTMLInputElement;

--- a/src/components/receipt-upload-documents/ReceiptUploadDocuments.test.tsx
+++ b/src/components/receipt-upload-documents/ReceiptUploadDocuments.test.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import { render, waitFor, screen } from "@testing-library/react";
 import { ReceiptUploadDocuments } from "./ReceiptUploadDocuments";
-import { SanityProvider } from "../../context/sanity-context";
-import { sanityMocks } from "../../__mocks__/sanity.mocks";
 import { ISoknadStatus } from "../../pages/api/soknad/[uuid]/status";
 import { sub, formatISO } from "date-fns";
+import { SetupContext } from "../../__mocks__/SetupContext";
 
 const soknadStatusMock: ISoknadStatus = {
   status: "UnderBehandling",
@@ -16,11 +15,11 @@ test("Should show link to ettersending if soknad is sent in within 12 weeks", as
   const innsendt = new Date();
 
   render(
-    <SanityProvider initialState={sanityMocks}>
+    <SetupContext>
       <ReceiptUploadDocuments
         soknadStatus={{ ...soknadStatusMock, innsendt: formatISO(innsendt) }}
       />
-    </SanityProvider>
+    </SetupContext>
   );
 
   await waitFor(() => {
@@ -34,11 +33,11 @@ describe("ReceiptUploadDocuments", () => {
     const outsideEttersendingBoundary = sub(innsendt, { weeks: 13 });
 
     render(
-      <SanityProvider initialState={sanityMocks}>
+      <SetupContext>
         <ReceiptUploadDocuments
           soknadStatus={{ ...soknadStatusMock, innsendt: formatISO(outsideEttersendingBoundary) }}
         />
-      </SanityProvider>
+      </SetupContext>
     );
 
     await waitFor(() => {

--- a/src/components/receipt-your-answers/ReceiptYourAnswers.tsx
+++ b/src/components/receipt-your-answers/ReceiptYourAnswers.tsx
@@ -18,10 +18,12 @@ export function ReceiptYourAnswers(props: IProps) {
         header={getAppText("kvittering.dine-svar.header")}
       >
         {props.sections?.map((section) => {
+          const sectionTexts = getSeksjonTextById(section.beskrivendeId);
+
           return (
             <Accordion.Item key={section.beskrivendeId}>
               <Accordion.Header>
-                {getSeksjonTextById(section.beskrivendeId)?.title}
+                {sectionTexts?.title ? sectionTexts?.title : section.beskrivendeId}
               </Accordion.Header>
               <Accordion.Content>
                 {section.fakta.map((faktum) => {

--- a/src/components/section/Section.test.tsx
+++ b/src/components/section/Section.test.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 import { render, waitFor, screen } from "@testing-library/react";
 import { Section } from "./Section";
-import { SanityProvider } from "../../context/sanity-context";
-import { IQuizSeksjon, IQuizState } from "../../types/quiz.types";
-import { QuizProvider } from "../../context/quiz-context";
-import { sanityMocks } from "../../__mocks__/sanity.mocks";
-import { ValidationProvider } from "../../context/validation-context";
+import { IQuizSeksjon } from "../../types/quiz.types";
+import { SetupContext } from "../../__mocks__/SetupContext";
 
 const sectionMockData: IQuizSeksjon = {
   fakta: [
@@ -27,22 +24,12 @@ const sectionMockData: IQuizSeksjon = {
   ferdig: true,
 };
 
-const mockSoknadState: IQuizState = {
-  ferdig: false,
-  antallSeksjoner: 11,
-  seksjoner: [sectionMockData],
-};
-
 describe("Section", () => {
   test("Should show section info and the first unanswered question", async () => {
     render(
-      <SanityProvider initialState={sanityMocks}>
-        <QuizProvider initialState={mockSoknadState}>
-          <ValidationProvider>
-            <Section section={sectionMockData} />
-          </ValidationProvider>
-        </QuizProvider>
-      </SanityProvider>
+      <SetupContext quizSeksjoner={[sectionMockData]}>
+        <Section section={sectionMockData} />
+      </SetupContext>
     );
 
     await waitFor(() => {

--- a/src/views/receipt/Receipt.test.tsx
+++ b/src/views/receipt/Receipt.test.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { render, waitFor, screen } from "@testing-library/react";
+import { Receipt } from "./Receipt";
+import { ISoknadStatus } from "../../pages/api/soknad/[uuid]/status";
+import { IQuizSeksjon, QuizFaktum } from "../../types/quiz.types";
+import userEvent from "@testing-library/user-event";
+import { SetupContext } from "../../__mocks__/SetupContext";
+import { IDokumentkrav } from "../../types/documentation.types";
+
+jest.mock("../../session.utils", () => {
+  return {
+    useSession: jest.fn(() => ({
+      session: { expiresIn: 1234 },
+      isLoading: false,
+      isError: false,
+    })),
+  };
+});
+
+const dokumentkrav: IDokumentkrav = {
+  id: "6679",
+  beskrivendeId: "dokumentasjonskrav.krav.arbeidsforhold",
+  beskrivelse: "Rema 1000",
+  fakta: [],
+  filer: [],
+  gyldigeValg: [
+    "dokumentkrav.svar.send.naa",
+    "dokumentkrav.svar.send.senere",
+    "dokumentkrav.svar.andre.sender",
+    "dokumentkrav.svar.sendt.tidligere",
+    "dokumentkrav.svar.sender.ikke",
+  ],
+  svar: "dokumentkrav.svar.send.senere",
+  begrunnelse: "Jeg skal sende disse senere.",
+};
+
+const faktumMockData: QuizFaktum = {
+  id: "10001",
+  svar: "faktum.mottatt-dagpenger-siste-12-mnd.svar.nei",
+  type: "envalg",
+  readOnly: false,
+  gyldigeValg: [
+    "faktum.mottatt-dagpenger-siste-12-mnd.svar.ja",
+    "faktum.mottatt-dagpenger-siste-12-mnd.svar.nei",
+    "faktum.mottatt-dagpenger-siste-12-mnd.svar.vet-ikke",
+  ],
+  beskrivendeId: "faktum.mottatt-dagpenger-siste-12-mnd",
+  sannsynliggjoresAv: [],
+  roller: [],
+};
+
+const sectionMockdata: IQuizSeksjon = {
+  fakta: [faktumMockData],
+  beskrivendeId: "din-situasjon",
+  ferdig: true,
+};
+
+const soknadStatus: ISoknadStatus = {
+  status: "UnderBehandling",
+  opprettet: "2022-10-21T09:42:37.291157",
+  innsendt: "2022-10-21T09:47:29",
+};
+
+describe("Receipt", () => {
+  test("Should show summary question and answers", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SetupContext quizSeksjoner={[sectionMockdata]}>
+        <Receipt
+          arbeidssokerStatus="REGISTERED"
+          soknadStatus={soknadStatus}
+          sections={[sectionMockdata]}
+        />
+      </SetupContext>
+    );
+
+    const expandSummaryButton = screen.getByRole("button", {
+      name: "kvittering.dine-svar.header",
+    });
+
+    user.click(expandSummaryButton);
+
+    await waitFor(() => {
+      // Await the accordion animating open
+      screen.findByText(sectionMockdata.beskrivendeId);
+
+      expect(screen.queryByText(faktumMockData.beskrivendeId)).toBeInTheDocument();
+      faktumMockData.svar && expect(screen.queryByText(faktumMockData.svar)).toBeInTheDocument();
+    });
+  });
+
+  describe("Arbeidssøkerstatus", () => {
+    test("Should show warning if user has not signed up as registrert arbeidssøker", async () => {
+      render(
+        <SetupContext>
+          <Receipt arbeidssokerStatus="UNREGISTERED" soknadStatus={soknadStatus} sections={[]} />
+        </SetupContext>
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("kvittering.arbeidssokerstatus.info-tekst.uregistrert")
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Dokumentasjonskrav", () => {
+    test("Should show dokumentkrav", async () => {
+      render(
+        <SetupContext dokumentkrav={[dokumentkrav]}>
+          <Receipt arbeidssokerStatus="REGISTERED" soknadStatus={soknadStatus} sections={[]} />
+        </SetupContext>
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText(dokumentkrav.beskrivendeId)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/views/summary/Summary.test.tsx
+++ b/src/views/summary/Summary.test.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { render, waitFor, screen } from "@testing-library/react";
+import { Summary } from "./Summary";
+import { IQuizSeksjon, QuizFaktum } from "../../types/quiz.types";
+import userEvent from "@testing-library/user-event";
+import { mockSoknadState, SetupContext } from "../../__mocks__/SetupContext";
+import fetch from "jest-fetch-mock";
+
+jest.mock("../../session.utils", () => {
+  return {
+    useSession: jest.fn(() => ({
+      session: { expiresIn: 1234 },
+      isLoading: false,
+      isError: false,
+    })),
+  };
+});
+
+const faktumMockData: QuizFaktum = {
+  id: "10001",
+  svar: "faktum.mottatt-dagpenger-siste-12-mnd.svar.nei",
+  type: "envalg",
+  readOnly: false,
+  gyldigeValg: [
+    "faktum.mottatt-dagpenger-siste-12-mnd.svar.ja",
+    "faktum.mottatt-dagpenger-siste-12-mnd.svar.nei",
+    "faktum.mottatt-dagpenger-siste-12-mnd.svar.vet-ikke",
+  ],
+  beskrivendeId: "faktum.mottatt-dagpenger-siste-12-mnd",
+  sannsynliggjoresAv: [],
+  roller: [],
+};
+
+const sectionMockdata: IQuizSeksjon = {
+  fakta: [faktumMockData],
+  beskrivendeId: "din-situasjon",
+  ferdig: true,
+};
+
+describe("Summary", () => {
+  beforeEach(() => {
+    fetch.enableMocks();
+  });
+
+  afterEach(() => {
+    fetch.mockReset();
+  });
+
+  test("Should show questions and answers", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SetupContext quizSeksjoner={[sectionMockdata]}>
+        <Summary />
+      </SetupContext>
+    );
+
+    const expandSectionButton = screen.getByRole("button", {
+      name: sectionMockdata.beskrivendeId,
+    });
+
+    user.click(expandSectionButton);
+
+    await waitFor(() => {
+      // Await the accordion animating open
+      screen.findByText(faktumMockData.beskrivendeId);
+
+      expect(screen.queryByText(faktumMockData.beskrivendeId)).toBeInTheDocument();
+      faktumMockData.svar && expect(screen.queryByText(faktumMockData.svar)).toBeInTheDocument();
+    });
+  });
+
+  test("Should show error message if user tries to send application without consenting", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SetupContext>
+        <Summary />
+      </SetupContext>
+    );
+
+    const sendApplicationButton = screen.getByRole("button", {
+      name: "oppsummering.knapp.send-soknad",
+    });
+
+    user.click(sendApplicationButton);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("oppsummering.checkbox.samtykke-riktige-opplysninger.validering-tekst")
+      ).toBeInTheDocument();
+
+      expect(fetch.mock.calls.length).toBe(0);
+    });
+  });
+
+  test("Should show error message if user tries to send a partially done application", async () => {
+    const user = userEvent.setup();
+
+    const quizState = { ...mockSoknadState };
+    quizState.ferdig = false;
+
+    render(
+      <SetupContext soknadState={quizState}>
+        <Summary />
+      </SetupContext>
+    );
+
+    const consentCheckbox = screen.getByRole("checkbox");
+
+    const sendApplicationButton = screen.getByRole("button", {
+      name: "oppsummering.knapp.send-soknad",
+    });
+
+    user.click(consentCheckbox);
+    user.click(sendApplicationButton);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("oppsummering.feilmelding.soknad-ikke-ferdig-utfylt")
+      ).toBeInTheDocument();
+
+      expect(fetch.mock.calls.length).toBe(0);
+    });
+  });
+
+  test("Should send the finished application", async () => {
+    fetch.mockResponseOnce("OK", { status: 200, statusText: "OK" });
+    const user = userEvent.setup();
+
+    const quizState = { ...mockSoknadState };
+    quizState.ferdig = true;
+
+    render(
+      <SetupContext soknadState={quizState}>
+        <Summary />
+      </SetupContext>
+    );
+
+    const consentCheckbox = screen.getByRole("checkbox");
+
+    const sendApplicationButton = screen.getByRole("button", {
+      name: "oppsummering.knapp.send-soknad",
+    });
+
+    user.click(consentCheckbox);
+    user.click(sendApplicationButton);
+
+    await waitFor(() => {
+      expect(fetch.mock.calls.length).toBe(1);
+    });
+  });
+});

--- a/src/views/summary/Summary.tsx
+++ b/src/views/summary/Summary.tsx
@@ -87,11 +87,12 @@ export function Summary() {
 
       <Accordion>
         {soknadState.seksjoner?.map((section, index) => {
+          const sectionTexts = getSeksjonTextById(section.beskrivendeId);
           return (
             <div key={section.beskrivendeId}>
               <Accordion.Item key={section.beskrivendeId}>
                 <Accordion.Header>
-                  {getSeksjonTextById(section.beskrivendeId)?.title}
+                  {sectionTexts?.title ? sectionTexts?.title : section.beskrivendeId}
 
                   {showSoknadNotCompleteError && !section.ferdig && (
                     <Tag variant="error" className={styles.notCompleteTag}>


### PR DESCRIPTION
Legger til tester for viewene `Summary` og `Receipt`. I tillegg fikser jeg en egen komponent `<SetupContext>` som inkluderer alle contextene vi kan trenge med barebones data. Slik blir testene våre enklere å lese og mindre repetitivt per test.

På oppsummeringen og kvitteringen viser vi svarene i en accordion. Legger til defaulting til beskrivendeId på seksjonene hvis tekster i Sanity mangler.