### PR TITLE
Oppdaterer arbeidssøker-apiet til å gå mot tokenX-enablet endepunkt

### DIFF
--- a/src/api.utils.ts
+++ b/src/api.utils.ts
@@ -2,6 +2,7 @@ import { v4 as uuidV4 } from "uuid";
 
 export const audienceDPSoknad = `${process.env.NAIS_CLUSTER_NAME}:teamdagpenger:dp-soknad`;
 export const audienceMellomlagring = `${process.env.NAIS_CLUSTER_NAME}:teamdagpenger:dp-mellomlagring`;
+export const audienceVeilarb = `${process.env.NAIS_CLUSTER_NAME}:paw:veilarbregistrering`;
 
 export default function api(endpoint: string): string {
   return `${process.env.NEXT_PUBLIC_BASE_PATH}/api${


### PR DESCRIPTION
PAW har skrevet om den delen av APIet som vi trenger for å hente ut arbeidssøkers perioder om til tokenX. Oppdaterer uthentingen vår, fikser riktig token og fjerner en gammel header som vi ikke trenger lenger.