### PR TITLE
Legger til ordentlig feilside når kall feiler på dokumentasjonssiden

### DIFF
--- a/src/pages/soknad/[uuid]/dokumentasjon.tsx
+++ b/src/pages/soknad/[uuid]/dokumentasjon.tsx
@@ -5,12 +5,12 @@ import { QuizProvider } from "../../../context/quiz-context";
 import { audienceDPSoknad } from "../../../api.utils";
 import { getSoknadState } from "../../../api/quiz-api";
 import { getDokumentkrav } from "../../api/documentation/[uuid]";
-import { Alert } from "@navikt/ds-react";
 import { IDokumentkravList } from "../../../types/documentation.types";
 import { mockDokumentkravList } from "../../../localhost-data/dokumentkrav-list";
 import { mockNeste } from "../../../localhost-data/mock-neste";
 import { IQuizState } from "../../../types/quiz.types";
 import { getSession } from "../../../auth.utils";
+import ErrorPage from "../../_error";
 
 interface IProps {
   errorCode: number | null;
@@ -82,17 +82,21 @@ export async function getServerSideProps(
 }
 
 export default function DocumentPage(props: IProps) {
-  if (!props.soknadState) {
-    return <Alert variant="error">Quiz er ducked</Alert>;
-  }
+  const { soknadState, dokumentkrav, errorCode } = props;
 
-  if (!props.dokumentkrav) {
-    return <Alert variant="info">Ingen dokumentasjonskrav tilgjengelig på søknaden</Alert>;
+  if (errorCode || !soknadState || !dokumentkrav) {
+    return (
+      <ErrorPage
+        title="Vi har tekniske problemer akkurat nå"
+        details="Beklager, vi får ikke kontakt med systemene våre. Svarene dine er lagret og du kan prøve igjen om litt."
+        statusCode={errorCode || 500}
+      />
+    );
   }
 
   return (
-    <QuizProvider initialState={props.soknadState}>
-      <Documentation dokumentkravList={props.dokumentkrav} />
+    <QuizProvider initialState={soknadState}>
+      <Documentation dokumentkravList={dokumentkrav} />
     </QuizProvider>
   );
 }


### PR DESCRIPTION
Fjerner `Quiz er ducked`, det er ikke helt heldig. Nå viser vi en ordentlig feilside hvis vi ikke får svar fra requestene for soknadState og dokumentasjonskrav, slik vi gjør på alle de andre sidene.