### PR TITLE
DAG-653: Vise varseltekst på landgruppe

### DIFF
--- a/src/components/faktum/faktum-land/FaktumLand.tsx
+++ b/src/components/faktum/faktum-land/FaktumLand.tsx
@@ -89,8 +89,8 @@ function FaktumLandComponent(
         description={faktumTexts?.description && <PortableText value={faktumTexts.description} />}
         onChange={(e) => onSelect(e.target.value)}
         options={options}
-        currentValue={currentAnswer || "Velg et land"}
-        placeHolderText={"Velg et land"}
+        currentValue={currentAnswer || getAppText("faktum-land.velg-et-land")}
+        placeHolderText={getAppText("faktum-land.velg-et-land")}
         error={
           unansweredFaktumId === faktum.id ? getAppText("validering.faktum.ubesvart") : undefined
         }

--- a/src/components/faktum/faktum-land/FaktumLand.tsx
+++ b/src/components/faktum/faktum-land/FaktumLand.tsx
@@ -13,6 +13,7 @@ import { useFirstRender } from "../../../hooks/useFirstRender";
 import styles from "../Faktum.module.css";
 import { ISanityLandGruppe } from "../../../types/sanity.types";
 import { AlertText } from "../../alert-text/AlertText";
+import { getLandGruppeId } from "../../../faktum.utils";
 
 export const FaktumLand = forwardRef(FaktumLandComponent);
 
@@ -62,7 +63,7 @@ function FaktumLandComponent(
 
   useEffect(() => {
     if (currentAnswer) {
-      const landGruppeId = getLandGruppeId(currentAnswer);
+      const landGruppeId = getLandGruppeId(faktum, currentAnswer);
       setLandGruppeText(getLandGruppeTextById(landGruppeId));
     }
   }, [currentAnswer]);
@@ -74,12 +75,6 @@ function FaktumLandComponent(
 
   function saveFaktum(value: string) {
     saveFaktumToQuiz(faktum, value);
-  }
-
-  function getLandGruppeId(code: string) {
-    const outsideLandGruppeId = `${faktum.beskrivendeId}.gruppe.utenfor-landgruppe`;
-    const currentLandGruppeId = faktum.grupper.find((group) => group.land.includes(code))?.gruppeId;
-    return currentLandGruppeId || outsideLandGruppeId;
   }
 
   return (

--- a/src/components/faktum/faktum-land/FaktumLandReadOnly.tsx
+++ b/src/components/faktum/faktum-land/FaktumLandReadOnly.tsx
@@ -8,12 +8,22 @@ import { IFaktumReadOnly } from "../Faktum";
 import { HelpText } from "../../HelpText";
 import styles from "../Faktum.module.css";
 import { PortableText } from "@portabletext/react";
+import { AlertText } from "../../alert-text/AlertText";
 
 export function FaktumLandReadOnly(props: IFaktumReadOnly<IQuizLandFaktum>) {
   const router = useRouter();
   const { faktum, showAllFaktumTexts } = props;
-  const { getFaktumTextById, getAppText } = useSanity();
+  const { getFaktumTextById, getAppText, getLandGruppeTextById } = useSanity();
   const faktumTexts = getFaktumTextById(faktum.beskrivendeId);
+
+  function getLandGruppeId(code: string) {
+    const outsideLandGruppeId = `${faktum.beskrivendeId}.gruppe.utenfor-landgruppe`;
+    const currentLandGruppeId = faktum.grupper.find((group) => group.land.includes(code))?.gruppeId;
+    return currentLandGruppeId || outsideLandGruppeId;
+  }
+
+  const landGruppeId = faktum.svar && getLandGruppeId(faktum.svar);
+  const landGruppeText = getLandGruppeTextById(landGruppeId);
 
   return (
     <>
@@ -35,6 +45,11 @@ export function FaktumLandReadOnly(props: IFaktumReadOnly<IQuizLandFaktum>) {
           defaultOpen={true}
         />
       )}
+
+      {showAllFaktumTexts &&
+        (landGruppeText?.alertText?.title || landGruppeText?.alertText?.body) && (
+          <AlertText alertText={landGruppeText.alertText} />
+        )}
     </>
   );
 }

--- a/src/components/faktum/faktum-land/FaktumLandReadOnly.tsx
+++ b/src/components/faktum/faktum-land/FaktumLandReadOnly.tsx
@@ -9,6 +9,7 @@ import { HelpText } from "../../HelpText";
 import styles from "../Faktum.module.css";
 import { PortableText } from "@portabletext/react";
 import { AlertText } from "../../alert-text/AlertText";
+import { getLandGruppeId } from "../../../faktum.utils";
 
 export function FaktumLandReadOnly(props: IFaktumReadOnly<IQuizLandFaktum>) {
   const router = useRouter();
@@ -16,13 +17,7 @@ export function FaktumLandReadOnly(props: IFaktumReadOnly<IQuizLandFaktum>) {
   const { getFaktumTextById, getAppText, getLandGruppeTextById } = useSanity();
   const faktumTexts = getFaktumTextById(faktum.beskrivendeId);
 
-  function getLandGruppeId(code: string) {
-    const outsideLandGruppeId = `${faktum.beskrivendeId}.gruppe.utenfor-landgruppe`;
-    const currentLandGruppeId = faktum.grupper.find((group) => group.land.includes(code))?.gruppeId;
-    return currentLandGruppeId || outsideLandGruppeId;
-  }
-
-  const landGruppeId = faktum.svar && getLandGruppeId(faktum.svar);
+  const landGruppeId = faktum.svar && getLandGruppeId(faktum, faktum.svar);
   const landGruppeText = getLandGruppeTextById(landGruppeId);
 
   return (

--- a/src/faktum.utils.ts
+++ b/src/faktum.utils.ts
@@ -1,7 +1,13 @@
 import { ARBEIDSFORHOLD_NAVN_BEDRIFT_FAKTUM_ID } from "./constants";
-import { QuizFaktum } from "./types/quiz.types";
+import { IQuizLandFaktum, QuizFaktum } from "./types/quiz.types";
 
 export function findEmployerName(fakta: QuizFaktum[]) {
   return fakta.find((faktum) => faktum.beskrivendeId === ARBEIDSFORHOLD_NAVN_BEDRIFT_FAKTUM_ID)
     ?.svar as string;
+}
+
+export function getLandGruppeId(faktum: IQuizLandFaktum, code: string) {
+  const outsideLandGruppeId = `${faktum.beskrivendeId}.gruppe.utenfor-landgruppe`;
+  const currentLandGruppeId = faktum.grupper.find((group) => group.land.includes(code))?.gruppeId;
+  return currentLandGruppeId || outsideLandGruppeId;
 }


### PR DESCRIPTION
Oppsett for å vise alerttekster både for spesifikke landgrupper og eventuelle land som faller utenfor de satte landgruppene.

Bildet under er for land utenfor landgrupper. Vi defaulter dermed til å prøve å hente tekster med nøkkel `${faktum.beskrivendeId}.gruppe.utenfor-landgruppe`. Hvis vi ikke finner noen tekster i Sanity viser vi ingenting.

![image](https://user-images.githubusercontent.com/3233286/214822216-fa55444f-fd13-4c45-afad-d42e7243a8b4.png)
