### PR TITLE
Fjern onchange i tester

### DIFF
--- a/src/__mocks__/MockContext.tsx
+++ b/src/__mocks__/MockContext.tsx
@@ -6,12 +6,14 @@ import { ValidationProvider } from "../context/validation-context";
 import { IDokumentkrav, IDokumentkravList } from "../types/documentation.types";
 import { IQuizSeksjon, IQuizState } from "../types/quiz.types";
 import { ISanityTexts } from "../types/sanity.types";
+import { MockQuizProvider } from "./MockQuizProvider";
 
 interface IProps {
   dokumentkrav?: IDokumentkrav[];
   soknadState?: IQuizState;
   quizSeksjoner?: IQuizSeksjon[];
   sanityTexts?: ISanityTexts;
+  mockQuizContext?: boolean;
 }
 
 export const mockSanityTexts: ISanityTexts = {
@@ -51,16 +53,27 @@ export function MockContext(props: PropsWithChildren<IProps>) {
     quizSeksjoner = [mockSection],
     soknadState = mockSoknadState,
     sanityTexts = mockSanityTexts,
+    mockQuizContext,
   } = props;
 
   return (
     <div id="__next">
       <SanityProvider initialState={sanityTexts}>
-        <QuizProvider initialState={{ ...soknadState, seksjoner: quizSeksjoner }}>
-          <DokumentkravProvider initialState={{ ...mockDokumentkravList, krav: dokumentkrav }}>
-            <ValidationProvider>{children}</ValidationProvider>
-          </DokumentkravProvider>
-        </QuizProvider>
+        {mockQuizContext && (
+          <MockQuizProvider initialState={{ ...soknadState, seksjoner: quizSeksjoner }}>
+            <DokumentkravProvider initialState={{ ...mockDokumentkravList, krav: dokumentkrav }}>
+              <ValidationProvider>{children}</ValidationProvider>
+            </DokumentkravProvider>
+          </MockQuizProvider>
+        )}
+
+        {!mockQuizContext && (
+          <QuizProvider initialState={{ ...soknadState, seksjoner: quizSeksjoner }}>
+            <DokumentkravProvider initialState={{ ...mockDokumentkravList, krav: dokumentkrav }}>
+              <ValidationProvider>{children}</ValidationProvider>
+            </DokumentkravProvider>
+          </QuizProvider>
+        )}
       </SanityProvider>
     </div>
   );

--- a/src/__mocks__/MockQuizProvider.tsx
+++ b/src/__mocks__/MockQuizProvider.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { QuizContext } from "../context/quiz-context";
+import { IQuizState } from "../types/quiz.types";
+
+interface IProps {
+  children: React.ReactElement;
+  initialState: IQuizState;
+}
+
+export const mockSaveFaktumToQuiz = jest.fn();
+export const mockSaveGeneratorFaktumToQuiz = jest.fn();
+
+export function MockQuizProvider({ initialState, children }: IProps) {
+  mockSaveFaktumToQuiz.mockReset();
+  mockSaveGeneratorFaktumToQuiz.mockReset();
+
+  return (
+    <QuizContext.Provider
+      value={{
+        soknadState: initialState,
+        saveFaktumToQuiz: mockSaveFaktumToQuiz,
+        saveGeneratorFaktumToQuiz: mockSaveGeneratorFaktumToQuiz,
+        isLoading: false,
+        isError: false,
+      }}
+    >
+      {children}
+    </QuizContext.Provider>
+  );
+}

--- a/src/components/faktum/Faktum.tsx
+++ b/src/components/faktum/Faktum.tsx
@@ -2,12 +2,7 @@ import React, { useEffect, useRef } from "react";
 import { FileContent } from "@navikt/ds-icons";
 import { FaktumEnvalg } from "./faktum-envalg/FaktumEnvalg";
 import { FaktumFlervalg } from "./faktum-flervalg/FaktumFlervalg";
-import {
-  IQuizGeneratorFaktum,
-  IQuizNumberFaktum,
-  QuizFaktum,
-  QuizFaktumSvarType,
-} from "../../types/quiz.types";
+import { IQuizGeneratorFaktum, IQuizNumberFaktum, QuizFaktum } from "../../types/quiz.types";
 import { FaktumText } from "./faktum-text/FaktumText";
 import { FaktumNumber } from "./faktum-number/FaktumNumber";
 import { FaktumDato } from "./faktum-dato/FaktumDato";
@@ -35,7 +30,6 @@ import { QUIZ_SOKNADSTYPE_DAGPENGESOKNAD } from "../../constants";
 
 export interface IFaktum<P> {
   faktum: P;
-  onChange?: (faktum: QuizFaktum, value: QuizFaktumSvarType) => void;
   readonly?: boolean;
   showAllFaktumTexts?: boolean;
 }
@@ -48,7 +42,7 @@ export interface IFaktumReadOnly<P> {
 const FAKTUM_GAARDSBRUK_ARBAAR_FOR_TIMER = "faktum.eget-gaardsbruk-arbeidsaar-for-timer";
 
 export function Faktum(props: IFaktum<QuizFaktum | IQuizGeneratorFaktum>) {
-  const { faktum, readonly, showAllFaktumTexts, onChange } = props;
+  const { faktum, readonly, showAllFaktumTexts } = props;
   const { soknadState } = useQuiz();
   const faktumRef = useRef(null);
   const { getAppText, getDokumentkravTextById } = useSanity();
@@ -75,11 +69,7 @@ export function Faktum(props: IFaktum<QuizFaktum | IQuizGeneratorFaktum>) {
       }
 
       return (
-        <FaktumEgetGaardsbrukArbeidsaar
-          ref={faktumRef}
-          faktum={faktum as IQuizNumberFaktum}
-          onChange={onChange}
-        />
+        <FaktumEgetGaardsbrukArbeidsaar ref={faktumRef} faktum={faktum as IQuizNumberFaktum} />
       );
     }
 
@@ -88,28 +78,28 @@ export function Faktum(props: IFaktum<QuizFaktum | IQuizGeneratorFaktum>) {
         if (faktum.readOnly || readonly) {
           return <FaktumBooleanReadOnly faktum={faktum} showAllFaktumTexts={showAllFaktumTexts} />;
         } else {
-          return <FaktumBoolean ref={faktumRef} faktum={faktum} onChange={onChange} />;
+          return <FaktumBoolean ref={faktumRef} faktum={faktum} />;
         }
 
       case "envalg":
         if (faktum.readOnly || readonly) {
           return <FaktumEnvalgReadOnly faktum={faktum} showAllFaktumTexts={showAllFaktumTexts} />;
         } else {
-          return <FaktumEnvalg ref={faktumRef} faktum={faktum} onChange={onChange} />;
+          return <FaktumEnvalg ref={faktumRef} faktum={faktum} />;
         }
 
       case "flervalg":
         if (faktum.readOnly || readonly) {
           return <FaktumFlervalgReadOnly faktum={faktum} showAllFaktumTexts={showAllFaktumTexts} />;
         } else {
-          return <FaktumFlervalg ref={faktumRef} faktum={faktum} onChange={onChange} />;
+          return <FaktumFlervalg ref={faktumRef} faktum={faktum} />;
         }
 
       case "tekst":
         if (faktum.readOnly || readonly) {
           return <FaktumTextReadOnly faktum={faktum} showAllFaktumTexts={showAllFaktumTexts} />;
         } else {
-          return <FaktumText ref={faktumRef} faktum={faktum} onChange={onChange} />;
+          return <FaktumText ref={faktumRef} faktum={faktum} />;
         }
 
       case "double":
@@ -117,28 +107,28 @@ export function Faktum(props: IFaktum<QuizFaktum | IQuizGeneratorFaktum>) {
         if (faktum.readOnly || readonly) {
           return <FaktumNumberReadOnly faktum={faktum} showAllFaktumTexts={showAllFaktumTexts} />;
         } else {
-          return <FaktumNumber ref={faktumRef} faktum={faktum} onChange={onChange} />;
+          return <FaktumNumber ref={faktumRef} faktum={faktum} />;
         }
 
       case "land":
         if (faktum.readOnly || readonly) {
           return <FaktumLandReadOnly faktum={faktum} showAllFaktumTexts={showAllFaktumTexts} />;
         } else {
-          return <FaktumLand ref={faktumRef} faktum={faktum} onChange={onChange} />;
+          return <FaktumLand ref={faktumRef} faktum={faktum} />;
         }
 
       case "localdate":
         if (faktum.readOnly || readonly) {
           return <FaktumDatoReadOnly faktum={faktum} showAllFaktumTexts={showAllFaktumTexts} />;
         } else {
-          return <FaktumDato ref={faktumRef} faktum={faktum} onChange={onChange} />;
+          return <FaktumDato ref={faktumRef} faktum={faktum} />;
         }
 
       case "periode":
         if (faktum.readOnly || readonly) {
           return <FaktumPeriodeReadOnly faktum={faktum} showAllFaktumTexts={showAllFaktumTexts} />;
         } else {
-          return <FaktumPeriode ref={faktumRef} faktum={faktum} onChange={onChange} />;
+          return <FaktumPeriode ref={faktumRef} faktum={faktum} />;
         }
 
       case "generator":

--- a/src/components/faktum/faktum-boolean/FaktumBoolean.test.tsx
+++ b/src/components/faktum/faktum-boolean/FaktumBoolean.test.tsx
@@ -6,6 +6,7 @@ import userEvent from "@testing-library/user-event";
 
 import * as SentryLogger from "../../../sentry.logger";
 import { MockContext } from "../../../__mocks__/MockContext";
+import { mockSaveFaktumToQuiz } from "../../../__mocks__/MockQuizProvider";
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
   id: "8007.1",
@@ -74,11 +75,10 @@ describe("FaktumBoolean", () => {
       const user = userEvent.setup();
       const svar = faktumMockData.gyldigeValg[1];
       const booleanSvar = textIdToBoolean(svar);
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumBoolean faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumBoolean faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -87,8 +87,8 @@ describe("FaktumBoolean", () => {
       user.click(radioToClick);
 
       await waitFor(() => {
-        expect(onchange).toBeCalledTimes(1);
-        expect(onchange).toBeCalledWith(faktumMockData, booleanSvar);
+        expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, booleanSvar);
       });
     });
   });

--- a/src/components/faktum/faktum-boolean/FaktumBoolean.tsx
+++ b/src/components/faktum/faktum-boolean/FaktumBoolean.tsx
@@ -20,7 +20,7 @@ function FaktumBooleanComponent(
   props: IFaktum<IQuizBooleanFaktum>,
   ref: Ref<HTMLFieldSetElement> | undefined
 ) {
-  const { faktum, onChange } = props;
+  const { faktum } = props;
   const isFirstRender = useFirstRender();
   const { saveFaktumToQuiz } = useQuiz();
   const { unansweredFaktumId } = useValidation();
@@ -55,7 +55,7 @@ function FaktumBooleanComponent(
       console.error("ERROR");
     }
 
-    onChange ? onChange(faktum, mappedAnswer) : saveFaktumToQuiz(faktum, mappedAnswer);
+    saveFaktumToQuiz(faktum, mappedAnswer);
   }
 
   if (!faktum.beskrivendeId) {

--- a/src/components/faktum/faktum-dato/FaktumDato.test.tsx
+++ b/src/components/faktum/faktum-dato/FaktumDato.test.tsx
@@ -86,7 +86,7 @@ describe("FaktumDato", () => {
 
       await waitFor(() => {
         expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
-        expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, "");
+        expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, null);
       });
     });
   });
@@ -266,7 +266,7 @@ describe("FaktumDato", () => {
 
         await waitFor(() => {
           expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
-          expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, "");
+          expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, null);
           expect(warningMessage).not.toBeInTheDocument();
         });
       });

--- a/src/components/faktum/faktum-dato/FaktumDato.test.tsx
+++ b/src/components/faktum/faktum-dato/FaktumDato.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { addWeeks, addYears, format, formatISO, subYears } from "date-fns";
 import { IQuizGeneratorFaktum, QuizFaktum } from "../../../types/quiz.types";
 import { MockContext } from "../../../__mocks__/MockContext";
+import { mockSaveFaktumToQuiz } from "../../../__mocks__/MockQuizProvider";
 import { FaktumDato } from "./FaktumDato";
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
@@ -52,11 +53,10 @@ describe("FaktumDato", () => {
   describe("When user selects an answer", () => {
     test("Should post the answer to the server", async () => {
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumDato faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumDato faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -64,8 +64,8 @@ describe("FaktumDato", () => {
       await user.type(datepicker, "04.08.2022");
 
       await waitFor(() => {
-        expect(onchange).toBeCalledTimes(1);
-        expect(onchange).toBeCalledWith(faktumMockData, "2022-08-04");
+        expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, "2022-08-04");
       });
     });
   });
@@ -74,11 +74,10 @@ describe("FaktumDato", () => {
     test("Should call saveFaktum and post null to server", async () => {
       faktumMockData.svar = "2022-08-04";
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumDato faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumDato faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -86,8 +85,8 @@ describe("FaktumDato", () => {
       await user.clear(datepicker);
 
       await waitFor(() => {
-        expect(onchange).toBeCalledTimes(1);
-        expect(onchange).toBeCalledWith(faktumMockData, "");
+        expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, "");
       });
     });
   });
@@ -98,11 +97,10 @@ describe("FaktumDato", () => {
       const datePickerFormattedDate = format(twoHundredYearsFromNow, "dd.MM.yyyy");
 
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumDato faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumDato faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -115,7 +113,7 @@ describe("FaktumDato", () => {
 
       await waitFor(() => {
         expect(datePickerError).toBeInTheDocument();
-        expect(onchange).not.toBeCalled();
+        expect(mockSaveFaktumToQuiz).not.toBeCalled();
       });
     });
 
@@ -124,11 +122,10 @@ describe("FaktumDato", () => {
       const datePickerFormattedDate = format(twoHundredYearsFromNow, "dd.MM.yyyy");
 
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumDato faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumDato faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -141,7 +138,7 @@ describe("FaktumDato", () => {
 
       await waitFor(() => {
         expect(datePickerError).toBeInTheDocument();
-        expect(onchange).not.toBeCalled();
+        expect(mockSaveFaktumToQuiz).not.toBeCalled();
       });
     });
   });
@@ -149,11 +146,10 @@ describe("FaktumDato", () => {
   describe("When user types in date without dot between date, month and year on datepicker. Eg. 10102022", () => {
     test("Should post 2022-10-10 to server because DDMMYYYY is also a valid format", async () => {
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumDato faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumDato faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -161,8 +157,8 @@ describe("FaktumDato", () => {
       await user.type(datepicker, "10102022");
 
       await waitFor(() => {
-        expect(onchange).toBeCalledTimes(1);
-        expect(onchange).toBeCalledWith(faktumMockData, "2022-10-10");
+        expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, "2022-10-10");
       });
     });
   });
@@ -170,11 +166,10 @@ describe("FaktumDato", () => {
   describe("When user types in different invalid date formats. Valid format is DDMMYYY, DD.MM.YYYY, DDMMYY or DD.MM.YY", () => {
     test("Types in 10.10 should call saveFaktum, post null to server and show error message", async () => {
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumDato faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumDato faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -185,18 +180,17 @@ describe("FaktumDato", () => {
       await user.type(datepicker, "10.10");
 
       await waitFor(() => {
-        expect(onchange).toBeCalledWith(faktumMockData, null);
+        expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, null);
         expect(datePickerError).toBeInTheDocument();
       });
     });
 
     test("Types in 1010 should call saveFaktum, post null to server and show error message", async () => {
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumDato faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumDato faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -207,8 +201,8 @@ describe("FaktumDato", () => {
       ) as HTMLInputElement;
 
       await waitFor(() => {
-        expect(onchange).toBeCalledTimes(1);
-        expect(onchange).toBeCalledWith(faktumMockData, null);
+        expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, null);
         expect(datePickerError).toBeInTheDocument();
       });
     });
@@ -225,11 +219,10 @@ describe("FaktumDato", () => {
         const isoFormattedDate = formatISO(threeWeeksFromNow, { representation: "date" }); // eg 2022-11-20
 
         const user = userEvent.setup();
-        const onchange = jest.fn();
 
         render(
-          <MockContext>
-            <FaktumDato faktum={faktumSoknadsdatoMockData} onChange={onchange} />
+          <MockContext mockQuizContext={true}>
+            <FaktumDato faktum={faktumSoknadsdatoMockData} />
           </MockContext>
         );
 
@@ -240,8 +233,8 @@ describe("FaktumDato", () => {
         const warningMessage = screen.getByTestId("faktum.soknadsdato-varsel");
 
         await waitFor(() => {
-          expect(onchange).toBeCalledTimes(1);
-          expect(onchange).toBeCalledWith(faktumSoknadsdatoMockData, isoFormattedDate);
+          expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+          expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumSoknadsdatoMockData, isoFormattedDate);
           expect(warningMessage).toBeInTheDocument();
         });
       });
@@ -255,11 +248,10 @@ describe("FaktumDato", () => {
         faktumMockData.svar = threeWeeksFromNotIsoFormatted;
 
         const user = userEvent.setup();
-        const onchange = jest.fn();
 
         render(
-          <MockContext>
-            <FaktumDato faktum={faktumMockData} onChange={onchange} />
+          <MockContext mockQuizContext={true}>
+            <FaktumDato faktum={faktumMockData} />
           </MockContext>
         );
 
@@ -273,8 +265,8 @@ describe("FaktumDato", () => {
         await user.clear(datepicker);
 
         await waitFor(() => {
-          expect(onchange).toBeCalledTimes(1);
-          expect(onchange).toBeCalledWith(faktumMockData, "");
+          expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+          expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, "");
           expect(warningMessage).not.toBeInTheDocument();
         });
       });
@@ -289,14 +281,13 @@ describe("FaktumDato", () => {
       };
 
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       const threeWeeksFromNow = addWeeks(new Date(), 3);
       const datePickerFormattedDate = format(threeWeeksFromNow, "dd.MM.yyyy");
 
       render(
-        <MockContext>
-          <FaktumDato faktum={faktumBarnFodselsdatoMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumDato faktum={faktumBarnFodselsdatoMockData} />
         </MockContext>
       );
 
@@ -310,7 +301,7 @@ describe("FaktumDato", () => {
 
       await waitFor(() => {
         expect(datePickerError).toBeInTheDocument();
-        expect(onchange).not.toBeCalled();
+        expect(mockSaveFaktumToQuiz).not.toBeCalled();
       });
     });
   });

--- a/src/components/faktum/faktum-dato/FaktumDato.tsx
+++ b/src/components/faktum/faktum-dato/FaktumDato.tsx
@@ -21,7 +21,7 @@ function FaktumDatoComponent(
   props: IFaktum<IQuizDatoFaktum>,
   ref: Ref<HTMLDivElement> | undefined
 ) {
-  const { faktum, onChange } = props;
+  const { faktum } = props;
   const isFirstRender = useFirstRender();
   const { saveFaktumToQuiz } = useQuiz();
   const { getFaktumTextById, getAppText } = useSanity();
@@ -35,7 +35,7 @@ function FaktumDatoComponent(
 
   useEffect(() => {
     if (!isFirstRender) {
-      onChange ? onChange(faktum, debouncedDate) : saveFaktum(debouncedDate);
+      saveFaktum(debouncedDate);
     }
   }, [debouncedDate]);
 

--- a/src/components/faktum/faktum-envalg/FaktumEnvalg.test.tsx
+++ b/src/components/faktum/faktum-envalg/FaktumEnvalg.test.tsx
@@ -4,6 +4,7 @@ import { FaktumEnvalg } from "./FaktumEnvalg";
 import { IQuizGeneratorFaktum, QuizFaktum } from "../../../types/quiz.types";
 import userEvent from "@testing-library/user-event";
 import { MockContext } from "../../../__mocks__/MockContext";
+import { mockSaveFaktumToQuiz } from "../../../__mocks__/MockQuizProvider";
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
   id: "10001",
@@ -60,11 +61,10 @@ describe("FaktumEnvalg", () => {
     test("Should post the answer to the server", async () => {
       const user = userEvent.setup();
       const svar = faktumMockData.gyldigeValg[0];
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumEnvalg faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumEnvalg faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -73,8 +73,8 @@ describe("FaktumEnvalg", () => {
       user.click(firstRadio);
 
       await waitFor(() => {
-        expect(onchange).toHaveBeenCalledTimes(1);
-        expect(onchange).toBeCalledWith(faktumMockData, svar);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, svar);
       });
     });
   });

--- a/src/components/faktum/faktum-envalg/FaktumEnvalg.tsx
+++ b/src/components/faktum/faktum-envalg/FaktumEnvalg.tsx
@@ -18,7 +18,7 @@ function FaktumEnvalgComponent(
   props: IFaktum<IQuizEnvalgFaktum>,
   ref: Ref<HTMLFieldSetElement> | undefined
 ) {
-  const { faktum, onChange } = props;
+  const { faktum } = props;
   const isFirstRender = useFirstRender();
   const { saveFaktumToQuiz } = useQuiz();
   const { unansweredFaktumId } = useValidation();
@@ -45,7 +45,7 @@ function FaktumEnvalgComponent(
   }
 
   function saveFaktum(value: string) {
-    onChange ? onChange(faktum, value) : saveFaktumToQuiz(faktum, value);
+    saveFaktumToQuiz(faktum, value);
   }
 
   return (

--- a/src/components/faktum/faktum-flervalg/FaktumFlervalg.test.tsx
+++ b/src/components/faktum/faktum-flervalg/FaktumFlervalg.test.tsx
@@ -4,6 +4,7 @@ import { render, waitFor, screen } from "@testing-library/react";
 import { FaktumFlervalg } from "./FaktumFlervalg";
 import { IQuizGeneratorFaktum, QuizFaktum } from "../../../types/quiz.types";
 import { MockContext } from "../../../__mocks__/MockContext";
+import { mockSaveFaktumToQuiz } from "../../../__mocks__/MockQuizProvider";
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
   id: "3008",
@@ -64,11 +65,10 @@ describe("FaktumFlervalg", () => {
     test("Should post the answer to the server", async () => {
       const user = userEvent.setup();
       const svar = [faktumMockData.gyldigeValg[1]];
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumFlervalg faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumFlervalg faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -77,19 +77,18 @@ describe("FaktumFlervalg", () => {
       user.click(svarCheckbox);
 
       await waitFor(() => {
-        expect(onchange).toBeCalledTimes(1);
-        expect(onchange).toHaveBeenCalledWith(faktumMockData, svar);
+        expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledWith(faktumMockData, svar);
       });
     });
 
     test("Can select multiple answers", async () => {
       const user = userEvent.setup();
       const svar = [faktumMockData.gyldigeValg[1], faktumMockData.gyldigeValg[2]];
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumFlervalg faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumFlervalg faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -100,8 +99,8 @@ describe("FaktumFlervalg", () => {
       user.click(svar2Checkbox);
 
       await waitFor(() => {
-        expect(onchange).toHaveBeenCalledTimes(2);
-        expect(onchange).toHaveBeenCalledWith(faktumMockData, svar);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledTimes(2);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledWith(faktumMockData, svar);
       });
     });
   });

--- a/src/components/faktum/faktum-flervalg/FaktumFlervalg.tsx
+++ b/src/components/faktum/faktum-flervalg/FaktumFlervalg.tsx
@@ -19,7 +19,7 @@ function FaktumFlervalgComponent(
   props: IFaktum<IQuizFlervalgFaktum>,
   ref: Ref<HTMLFieldSetElement> | undefined
 ) {
-  const { faktum, onChange } = props;
+  const { faktum } = props;
   const { saveFaktumToQuiz } = useQuiz();
   const isFirstRender = useFirstRender();
   const { unansweredFaktumId } = useValidation();
@@ -44,7 +44,7 @@ function FaktumFlervalgComponent(
   }, [faktum.svar]);
 
   function onSelection(value: string[]) {
-    onChange ? onChange(faktum, value) : saveFaktum(value);
+    saveFaktum(value);
     setCurrentAnswer(value);
   }
 

--- a/src/components/faktum/faktum-land/FaktumLand.test.tsx
+++ b/src/components/faktum/faktum-land/FaktumLand.test.tsx
@@ -5,6 +5,7 @@ import { FaktumLand } from "./FaktumLand";
 import { IQuizGeneratorFaktum, QuizFaktum } from "../../../types/quiz.types";
 import { getCountryName } from "../../../country.utils";
 import { MockContext } from "../../../__mocks__/MockContext";
+import { mockSaveFaktumToQuiz } from "../../../__mocks__/MockQuizProvider";
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
   id: "6001",
@@ -114,11 +115,10 @@ describe("FaktumLand", () => {
     test("Should post it to the server", async () => {
       const user = userEvent.setup();
       const svar = faktumMockDataBostedsland.gyldigeLand[14];
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumLand faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumLand faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -127,8 +127,8 @@ describe("FaktumLand", () => {
       user.selectOptions(screen.getByLabelText(faktumMockData.beskrivendeId), selectedOptionText);
 
       await waitFor(() => {
-        expect(onchange).toBeCalledTimes(1);
-        expect(onchange).toBeCalledWith(faktumMockData, svar);
+        expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, svar);
       });
     });
   });
@@ -136,19 +136,18 @@ describe("FaktumLand", () => {
   describe("When is Bodstedsland or Arbeidsforhold and faktum is unanswered", () => {
     test("Should post `NOR` to server", async () => {
       const svar = "NOR";
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumLand faktum={faktumMockDataBostedsland} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumLand faktum={faktumMockDataBostedsland} />
         </MockContext>
       );
 
       await waitFor(() => {
         const selectedOption = screen.getByRole("option", { selected: true }) as HTMLInputElement;
         expect(selectedOption.value).toEqual(svar);
-        expect(onchange).toBeCalledTimes(1);
-        expect(onchange).toBeCalledWith(faktumMockDataBostedsland, svar);
+        expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockDataBostedsland, svar);
       });
     });
   });

--- a/src/components/faktum/faktum-land/FaktumLand.tsx
+++ b/src/components/faktum/faktum-land/FaktumLand.tsx
@@ -22,7 +22,7 @@ function FaktumLandComponent(
   ref: Ref<HTMLDivElement> | undefined
 ) {
   const router = useRouter();
-  const { faktum, onChange } = props;
+  const { faktum } = props;
   const isFirstRender = useFirstRender();
   const { saveFaktumToQuiz } = useQuiz();
   const { unansweredFaktumId } = useValidation();
@@ -69,7 +69,7 @@ function FaktumLandComponent(
   }, [currentAnswer]);
 
   function onSelect(value: string) {
-    onChange ? onChange(faktum, value) : saveFaktum(value);
+    saveFaktum(value);
     setCurrentAnswer(value);
   }
 

--- a/src/components/faktum/faktum-number/FaktumNumber.test.tsx
+++ b/src/components/faktum/faktum-number/FaktumNumber.test.tsx
@@ -4,6 +4,7 @@ import { render, waitFor, screen } from "@testing-library/react";
 import { FaktumNumber } from "./FaktumNumber";
 import { IQuizGeneratorFaktum, QuizFaktum } from "../../../types/quiz.types";
 import { MockContext } from "../../../__mocks__/MockContext";
+import { mockSaveFaktumToQuiz } from "../../../__mocks__/MockQuizProvider";
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
   beskrivendeId: "faktum.barn-inntekt",
@@ -51,11 +52,10 @@ describe("FaktumNumber", () => {
     test("Should post the answer to the server", async () => {
       const user = userEvent.setup();
       const svar = 14;
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumNumber faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumNumber faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -64,8 +64,8 @@ describe("FaktumNumber", () => {
       await user.type(textInput, svar + "");
 
       await waitFor(() => {
-        expect(onchange).toHaveBeenCalledTimes(1);
-        expect(onchange).toHaveBeenCalledWith(faktumMockData, svar);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledWith(faktumMockData, svar);
       });
     });
   });

--- a/src/components/faktum/faktum-number/FaktumNumber.tsx
+++ b/src/components/faktum/faktum-number/FaktumNumber.tsx
@@ -18,7 +18,7 @@ function FaktumNumberComponent(
   props: IFaktum<IQuizNumberFaktum>,
   ref: Ref<HTMLInputElement> | undefined
 ) {
-  const { faktum, onChange } = props;
+  const { faktum } = props;
   const isFirstRender = useFirstRender();
   const { saveFaktumToQuiz } = useQuiz();
   const { getFaktumTextById, getAppText } = useSanity();
@@ -31,7 +31,7 @@ function FaktumNumberComponent(
 
   useEffect(() => {
     if (!isFirstRender && debouncedValue !== faktum.svar) {
-      onChange ? onChange(faktum, debouncedValue) : saveFaktum(debouncedValue);
+      saveFaktum(debouncedValue);
     }
   }, [debouncedValue]);
 

--- a/src/components/faktum/faktum-periode/FaktumPeriode.test.tsx
+++ b/src/components/faktum/faktum-periode/FaktumPeriode.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { addDays, format, formatISO } from "date-fns";
 import { IQuizGeneratorFaktum, QuizFaktum } from "../../../types/quiz.types";
 import { MockContext } from "../../../__mocks__/MockContext";
+import { mockSaveFaktumToQuiz } from "../../../__mocks__/MockQuizProvider";
 import { FaktumPeriode } from "./FaktumPeriode";
 
 const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
@@ -63,11 +64,10 @@ describe("FaktumPeriode", () => {
   describe("When user selects from date", () => {
     test("Should post selected from date to the server", async () => {
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumPeriode faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumPeriode faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -77,8 +77,8 @@ describe("FaktumPeriode", () => {
       await user.type(datepickerFom, "04.08.2022");
 
       await waitFor(() => {
-        expect(onchange).toBeCalledTimes(1);
-        expect(onchange).toHaveBeenCalledWith(faktumMockData, { fom: "2022-08-04" });
+        expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledWith(faktumMockData, { fom: "2022-08-04" });
       });
     });
   });
@@ -89,11 +89,10 @@ describe("FaktumPeriode", () => {
       faktumMockData.svar = svar;
 
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumPeriode faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumPeriode faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -112,8 +111,8 @@ describe("FaktumPeriode", () => {
       await user.type(datepickerTom, "06.08.2022");
 
       await waitFor(() => {
-        expect(onchange).toBeCalledTimes(1);
-        expect(onchange).toHaveBeenCalledWith(faktumMockData, {
+        expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledWith(faktumMockData, {
           fom: "2022-08-04",
           tom: "2022-08-06",
         });
@@ -196,11 +195,10 @@ describe("FaktumPeriode", () => {
   describe("When selected date is not within 01.01.1900 and 100 year from now", () => {
     test("When types inn 01.01.1800 should show error message and not post to server", async () => {
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumPeriode faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumPeriode faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -216,17 +214,16 @@ describe("FaktumPeriode", () => {
 
       await waitFor(() => {
         expect(datePickerError).toBeInTheDocument();
-        expect(onchange).not.toBeCalled();
+        expect(mockSaveFaktumToQuiz).not.toBeCalled();
       });
     });
 
     test("When types in 06.06.2322 should show error message not post to server", async () => {
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumPeriode faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumPeriode faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -242,7 +239,7 @@ describe("FaktumPeriode", () => {
 
       await waitFor(() => {
         expect(datePickerError).toBeInTheDocument();
-        expect(onchange).not.toBeCalled();
+        expect(mockSaveFaktumToQuiz).not.toBeCalled();
       });
     });
   });
@@ -257,11 +254,10 @@ describe("FaktumPeriode", () => {
       const isoFormattedDate = formatISO(tenDaysFromNow, { representation: "date" });
 
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumPeriode faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumPeriode faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -272,8 +268,8 @@ describe("FaktumPeriode", () => {
       await user.type(datepickerFom, datePickerFormattedDate);
 
       await waitFor(() => {
-        expect(onchange).toBeCalledTimes(1);
-        expect(onchange).toHaveBeenCalledWith(faktumMockData, {
+        expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledWith(faktumMockData, {
           fom: isoFormattedDate,
         });
       });
@@ -286,11 +282,10 @@ describe("FaktumPeriode", () => {
       faktumMockData.svar = svar;
 
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumPeriode faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumPeriode faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -301,8 +296,8 @@ describe("FaktumPeriode", () => {
       await user.clear(datepickerFom);
 
       await waitFor(() => {
-        expect(onchange).toBeCalledTimes(1);
-        expect(onchange).toHaveBeenCalledWith(faktumMockData, null);
+        expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledWith(faktumMockData, null);
       });
     });
 
@@ -311,11 +306,10 @@ describe("FaktumPeriode", () => {
       faktumMockData.svar = svar;
 
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumPeriode faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumPeriode faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -326,8 +320,8 @@ describe("FaktumPeriode", () => {
       await user.clear(datepickerFom);
 
       await waitFor(() => {
-        expect(onchange).toBeCalledTimes(1);
-        expect(onchange).toHaveBeenCalledWith(faktumMockData, null);
+        expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledWith(faktumMockData, null);
       });
     });
 
@@ -336,11 +330,10 @@ describe("FaktumPeriode", () => {
       faktumMockData.svar = svar;
 
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumPeriode faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumPeriode faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -351,8 +344,8 @@ describe("FaktumPeriode", () => {
       await user.clear(datepickerTom);
 
       await waitFor(() => {
-        expect(onchange).toBeCalledTimes(1);
-        expect(onchange).toHaveBeenCalledWith(faktumMockData, { fom: "2022-08-04" });
+        expect(mockSaveFaktumToQuiz).toBeCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledWith(faktumMockData, { fom: "2022-08-04" });
       });
     });
   });

--- a/src/components/faktum/faktum-periode/FaktumPeriode.tsx
+++ b/src/components/faktum/faktum-periode/FaktumPeriode.tsx
@@ -26,7 +26,7 @@ function FaktumPeriodeComponent(
   props: IFaktum<IQuizPeriodeFaktum>,
   ref: Ref<HTMLDivElement> | undefined
 ) {
-  const { faktum, onChange } = props;
+  const { faktum } = props;
   const isFirstRender = useFirstRender();
   const { saveFaktumToQuiz } = useQuiz();
   const { getFaktumTextById, getAppText } = useSanity();
@@ -46,7 +46,7 @@ function FaktumPeriodeComponent(
 
   useEffect(() => {
     if (!isFirstRender) {
-      onChange ? onChange(faktum, debouncedPeriode) : saveFaktum(debouncedPeriode);
+      saveFaktum(debouncedPeriode);
     }
   }, [debouncedPeriode]);
 

--- a/src/components/faktum/faktum-special-cases/FaktumEgetGaardsbrukArbeidsaar.tsx
+++ b/src/components/faktum/faktum-special-cases/FaktumEgetGaardsbrukArbeidsaar.tsx
@@ -20,7 +20,7 @@ function FaktumEgetGaardsbrukArbeidsaarComponent(
   props: IFaktum<IQuizNumberFaktum>,
   ref: Ref<HTMLDivElement> | undefined
 ) {
-  const { faktum, onChange } = props;
+  const { faktum } = props;
   const { saveFaktumToQuiz } = useQuiz();
   const { unansweredFaktumId } = useValidation();
   const { getAppText } = useSanity();
@@ -30,7 +30,7 @@ function FaktumEgetGaardsbrukArbeidsaarComponent(
   function handleOnSelect(event: ChangeEvent<HTMLSelectElement>) {
     const value = parseInt(event.target.value);
     setCurrentAnswer(value);
-    onChange ? onChange(faktum, value) : saveFaktum(value);
+    saveFaktum(value);
   }
 
   function saveFaktum(value: number) {

--- a/src/components/faktum/faktum-text/FaktumText.test.tsx
+++ b/src/components/faktum/faktum-text/FaktumText.test.tsx
@@ -70,7 +70,7 @@ describe("FaktumText", () => {
       });
     });
 
-    test.skip("Should show error on invalid input", async () => {
+    test("Should show error on invalid input", async () => {
       const inValidTextLengthMock =
         "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like.";
       const errorTextKey = "validering.text-faktum.for-lang-tekst";

--- a/src/components/faktum/faktum-text/FaktumText.test.tsx
+++ b/src/components/faktum/faktum-text/FaktumText.test.tsx
@@ -4,6 +4,7 @@ import { FaktumText } from "./FaktumText";
 import { IQuizTekstFaktum } from "../../../types/quiz.types";
 import userEvent from "@testing-library/user-event";
 import { MockContext } from "../../../__mocks__/MockContext";
+import { mockSaveFaktumToQuiz } from "../../../__mocks__/MockQuizProvider";
 
 const faktumMockData: IQuizTekstFaktum = {
   id: "8004.1",
@@ -53,11 +54,10 @@ describe("FaktumText", () => {
     test("Should post the answer to the server", async () => {
       const user = userEvent.setup();
       const svar = "Hei på du";
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumText faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumText faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -65,8 +65,8 @@ describe("FaktumText", () => {
       await user.type(textInput, svar);
 
       await waitFor(() => {
-        expect(onchange).toHaveBeenCalledTimes(1);
-        expect(onchange).toHaveBeenCalledWith(faktumMockData, svar);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledTimes(1);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledWith(faktumMockData, svar);
       });
     });
 
@@ -75,11 +75,10 @@ describe("FaktumText", () => {
         "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like.";
       const errorTextKey = "validering.text-faktum.for-lang-tekst";
       const user = userEvent.setup();
-      const onchange = jest.fn();
 
       render(
-        <MockContext>
-          <FaktumText faktum={faktumMockData} onChange={onchange} />
+        <MockContext mockQuizContext={true}>
+          <FaktumText faktum={faktumMockData} />
         </MockContext>
       );
 
@@ -88,7 +87,7 @@ describe("FaktumText", () => {
 
       await waitFor(() => {
         expect(textInput.value).toEqual(inValidTextLengthMock);
-        expect(onchange).toHaveBeenCalledTimes(0);
+        expect(mockSaveFaktumToQuiz).toHaveBeenCalledTimes(0);
         const errorText = screen.getByText(errorTextKey);
         expect(errorText).toBeInTheDocument();
       });

--- a/src/components/faktum/faktum-text/FaktumText.tsx
+++ b/src/components/faktum/faktum-text/FaktumText.tsx
@@ -19,7 +19,7 @@ export function FaktumTextComponent(
   props: IFaktum<IQuizTekstFaktum>,
   ref: Ref<HTMLInputElement> | undefined
 ) {
-  const { faktum, onChange } = props;
+  const { faktum } = props;
   const isFirstRender = useFirstRender();
   const { saveFaktumToQuiz } = useQuiz();
   const { unansweredFaktumId } = useValidation();
@@ -35,7 +35,7 @@ export function FaktumTextComponent(
   useEffect(() => {
     if (!isFirstRender && debouncedText !== faktum.svar) {
       const inputValue = debouncedText.length === 0 ? null : debouncedText;
-      onChange ? onChange(faktum, inputValue) : saveFaktum(inputValue);
+      saveFaktum(inputValue);
     }
   }, [debouncedText]);
 


### PR DESCRIPTION
Får sannsynligvis noen merge conflicts her, men det får så være. 😄 

Fjerner onChange på Faktum, det var et ubrukt felt alle andre steder enn i testene, som ga testene mindre verdi. Har i stedet mocket ut QuizContext, slik at vi kan lytte på lagring av faktum til Quiz.