### PR TITLE
DAG-766: Fikse Periode faktum validering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "dependencies": {
         "@amplitude/analytics-browser": "^1.6.7",
         "@navikt/dp-auth": "^0.3.1",
-        "@navikt/ds-css": "^2.0.11",
-        "@navikt/ds-icons": "^2.0.11",
-        "@navikt/ds-react": "^2.1.5",
+        "@navikt/ds-css": "^2.1.7",
+        "@navikt/ds-icons": "^2.1.7",
+        "@navikt/ds-react": "^2.1.7",
         "@navikt/fnrvalidator": "^1.3.3",
         "@navikt/nav-dekoratoren-moduler": "^1.8.1",
         "@next/bundle-analyzer": "^13.1.1",
@@ -2795,15 +2795,15 @@
       }
     },
     "node_modules/@navikt/ds-css": {
-      "version": "2.0.11",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/2.0.11/b5804628c7444bc4c663003dc22eade72a504841",
-      "integrity": "sha512-pZnLmCPJ07afdrJxMcVrgMzmmHZntPJeAiQ5L6Wj+v6gzwsiPqdxQ00ASpt9YRef3AuksM6lW/M4S9vMTpnOdg==",
+      "version": "2.1.7",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/2.1.7/80f2a8fe2680ad118ccf9e1bdaba75ff3004df05",
+      "integrity": "sha512-Dq/vFsGqnmVQCRWGLIzOB7XaFWgJRYVnbA2n4lfcnovp+zCwql1NNXKscvVWqaQEbq+2bGR71A5bgrr4NCR14w==",
       "license": "MIT"
     },
     "node_modules/@navikt/ds-icons": {
-      "version": "2.1.5",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-icons/2.1.5/7ed06e53d93dfa514ffaa324df96c0650eba701b",
-      "integrity": "sha512-klzs6ub3a8Y4iQ6PqenQzTApWwtBwZwQNc3TNPryvIiSfkHx1emDv9PUPNyxBXySAknI4jHVKOUosgf11giOhg==",
+      "version": "2.1.7",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-icons/2.1.7/4c38de9400fff6502ce7ba0509e05f770af66921",
+      "integrity": "sha512-1QGVRkkjPeqPRJg3kbO5WcWLIkronMNmz4m1MFC+HPZ4+Dp4WXIHeBUi6b13rrJAXBxb2Dun+gpbXxSzPxx79A==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^17.0.30 || ^18.0.0",
@@ -2811,13 +2811,13 @@
       }
     },
     "node_modules/@navikt/ds-react": {
-      "version": "2.1.5",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/2.1.5/53bcd690ed032ef7845c4651426dd79689e07ad3",
-      "integrity": "sha512-bQaQ/AWQELexCoD6s86nF/FqHzTIsqIOq63MYfDmESoCEzA61kb+KdgWi4NKwnuOiyV+rfu1GNSOu9hjfi2aOg==",
+      "version": "2.1.7",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/2.1.7/71ac60f7d929a34697b89874d03bd53d6b382691",
+      "integrity": "sha512-3IX4YfCbxS+ZsU/F2e9icIpacGDuZI8GEVFXZexOgWA7LfpK7a4Maif2Xi+pFo6mgmQUV6PJW4XCP417MjVrmQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "0.17.0",
-        "@navikt/ds-icons": "^2.1.5",
+        "@navikt/ds-icons": "^2.1.7",
         "@radix-ui/react-tabs": "1.0.0",
         "@radix-ui/react-toggle-group": "1.0.0",
         "clsx": "^1.2.1",
@@ -16844,23 +16844,23 @@
       }
     },
     "@navikt/ds-css": {
-      "version": "2.0.11",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/2.0.11/b5804628c7444bc4c663003dc22eade72a504841",
-      "integrity": "sha512-pZnLmCPJ07afdrJxMcVrgMzmmHZntPJeAiQ5L6Wj+v6gzwsiPqdxQ00ASpt9YRef3AuksM6lW/M4S9vMTpnOdg=="
+      "version": "2.1.7",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/2.1.7/80f2a8fe2680ad118ccf9e1bdaba75ff3004df05",
+      "integrity": "sha512-Dq/vFsGqnmVQCRWGLIzOB7XaFWgJRYVnbA2n4lfcnovp+zCwql1NNXKscvVWqaQEbq+2bGR71A5bgrr4NCR14w=="
     },
     "@navikt/ds-icons": {
-      "version": "2.1.5",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-icons/2.1.5/7ed06e53d93dfa514ffaa324df96c0650eba701b",
-      "integrity": "sha512-klzs6ub3a8Y4iQ6PqenQzTApWwtBwZwQNc3TNPryvIiSfkHx1emDv9PUPNyxBXySAknI4jHVKOUosgf11giOhg==",
+      "version": "2.1.7",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-icons/2.1.7/4c38de9400fff6502ce7ba0509e05f770af66921",
+      "integrity": "sha512-1QGVRkkjPeqPRJg3kbO5WcWLIkronMNmz4m1MFC+HPZ4+Dp4WXIHeBUi6b13rrJAXBxb2Dun+gpbXxSzPxx79A==",
       "requires": {}
     },
     "@navikt/ds-react": {
-      "version": "2.1.5",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/2.1.5/53bcd690ed032ef7845c4651426dd79689e07ad3",
-      "integrity": "sha512-bQaQ/AWQELexCoD6s86nF/FqHzTIsqIOq63MYfDmESoCEzA61kb+KdgWi4NKwnuOiyV+rfu1GNSOu9hjfi2aOg==",
+      "version": "2.1.7",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/2.1.7/71ac60f7d929a34697b89874d03bd53d6b382691",
+      "integrity": "sha512-3IX4YfCbxS+ZsU/F2e9icIpacGDuZI8GEVFXZexOgWA7LfpK7a4Maif2Xi+pFo6mgmQUV6PJW4XCP417MjVrmQ==",
       "requires": {
         "@floating-ui/react": "0.17.0",
-        "@navikt/ds-icons": "^2.1.5",
+        "@navikt/ds-icons": "^2.1.7",
         "@radix-ui/react-tabs": "1.0.0",
         "@radix-ui/react-toggle-group": "1.0.0",
         "clsx": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   "dependencies": {
     "@amplitude/analytics-browser": "^1.6.7",
     "@navikt/dp-auth": "^0.3.1",
-    "@navikt/ds-css": "^2.0.11",
-    "@navikt/ds-icons": "^2.0.11",
-    "@navikt/ds-react": "^2.1.5",
+    "@navikt/ds-css": "^2.1.7",
+    "@navikt/ds-icons": "^2.1.7",
+    "@navikt/ds-react": "^2.1.7",
     "@navikt/fnrvalidator": "^1.3.3",
     "@navikt/nav-dekoratoren-moduler": "^1.8.1",
     "@next/bundle-analyzer": "^13.1.1",

--- a/src/__mocks__/MockQuizProvider.tsx
+++ b/src/__mocks__/MockQuizProvider.tsx
@@ -22,6 +22,7 @@ export function MockQuizProvider({ initialState, children }: IProps) {
         saveGeneratorFaktumToQuiz: mockSaveGeneratorFaktumToQuiz,
         isLoading: false,
         isError: false,
+        isLocked: false,
       }}
     >
       {children}

--- a/src/components/arbeidsforhold/Arbeidsforhold.tsx
+++ b/src/components/arbeidsforhold/Arbeidsforhold.tsx
@@ -150,7 +150,7 @@ export function getArbeidsforholdVarighet(arbeidsforhold: QuizFaktum[]) {
 
   return (
     <>
-      <FormattedDate date={varighetFaktum.fom} />
+      {varighetFaktum.fom && <FormattedDate date={varighetFaktum.fom} />}
       {varighetFaktum.tom && (
         <>
           {`- `}

--- a/src/components/faktum/faktum-dato/FaktumDato.test.tsx
+++ b/src/components/faktum/faktum-dato/FaktumDato.test.tsx
@@ -14,6 +14,8 @@ const faktumMockData: QuizFaktum | IQuizGeneratorFaktum = {
   sannsynliggjoresAv: [],
 };
 
+jest.setTimeout(10000);
+
 describe("FaktumDato", () => {
   // Undo any answer after each test
   beforeEach(() => (faktumMockData.svar = undefined));

--- a/src/components/faktum/faktum-dato/FaktumDato.test.tsx
+++ b/src/components/faktum/faktum-dato/FaktumDato.test.tsx
@@ -92,7 +92,7 @@ describe("FaktumDato", () => {
   });
 
   describe("When selected date is not within 01.01.1900 and 100 year from now", () => {
-    test("Selecting a date two hundret years from now should show error message and not post to server", async () => {
+    test("Selecting a date two hundret years from now should show error message and not post null server", async () => {
       const twoHundredYearsFromNow = addYears(new Date(), 200);
       const datePickerFormattedDate = format(twoHundredYearsFromNow, "dd.MM.yyyy");
 
@@ -113,11 +113,11 @@ describe("FaktumDato", () => {
 
       await waitFor(() => {
         expect(datePickerError).toBeInTheDocument();
-        expect(mockSaveFaktumToQuiz).not.toBeCalled();
+        expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, null);
       });
     });
 
-    test("Selecting a date two hundret years before now should show error message and not post to server", async () => {
+    test("Selecting a date two hundret years before now should show error message and post null to server", async () => {
       const twoHundredYearsFromNow = subYears(new Date(), -200);
       const datePickerFormattedDate = format(twoHundredYearsFromNow, "dd.MM.yyyy");
 
@@ -138,7 +138,7 @@ describe("FaktumDato", () => {
 
       await waitFor(() => {
         expect(datePickerError).toBeInTheDocument();
-        expect(mockSaveFaktumToQuiz).not.toBeCalled();
+        expect(mockSaveFaktumToQuiz).toBeCalledWith(faktumMockData, null);
       });
     });
   });

--- a/src/components/faktum/faktum-periode/FaktumPeriode.tsx
+++ b/src/components/faktum/faktum-periode/FaktumPeriode.tsx
@@ -58,10 +58,10 @@ function FaktumPeriodeComponent(
 
   // Used to reset current answer to what the backend state is if there is a mismatch
   useEffect(() => {
-    if (!faktum.svar && !isFirstRender) {
-      setCurrentAnswer(initialPeriodeValue);
+    if (faktum.svar && !isFirstRender) {
+      setCurrentAnswer({ fom: faktum.svar.fom, tom: faktum.svar.tom });
     }
-  }, [faktum]);
+  }, [faktum.svar]);
 
   function getDefaultSelectedValue(): IDateRange | undefined {
     if (currentAnswer?.fom) {
@@ -77,7 +77,6 @@ function FaktumPeriodeComponent(
   const { datepickerProps, toInputProps, fromInputProps, setSelected } = UNSAFE_useRangeDatepicker({
     defaultSelected: getDefaultSelectedValue(),
     onRangeChange: (value?: IDateRange) => {
-      // When user clears `from date input` or types in invalid date format
       if (!value?.from) {
         setCurrentAnswer(initialPeriodeValue);
         debouncedChange(initialPeriodeValue);
@@ -98,12 +97,9 @@ function FaktumPeriodeComponent(
       }
     },
     onValidate: (value) => {
+      // Empty `to date input` programmatically when user clears `from date input`
       if (value.from.isEmpty) {
-        // Empty `to date input` programmatically when user clears `from date input`
         setSelected({ from: undefined });
-        setCurrentAnswer(initialPeriodeValue);
-        debouncedChange(initialPeriodeValue);
-        return;
       }
 
       // When user types in invalid date format on `from date input`
@@ -112,15 +108,6 @@ function FaktumPeriodeComponent(
         const periode = { ...currentAnswer, fom: null };
         setCurrentAnswer(periode);
         debouncedChange(periode);
-        return;
-      }
-
-      // Only save fom to state when `to date input` is empty
-      if (value.to.isEmpty) {
-        const periode = { fom: currentAnswer.fom };
-        setCurrentAnswer(periode);
-        debouncedChange(periode);
-        return;
       }
 
       // When user types in invalid `to date input`
@@ -129,7 +116,6 @@ function FaktumPeriodeComponent(
         const periode = { ...currentAnswer, tom: null };
         setCurrentAnswer(periode);
         debouncedChange(periode);
-        return;
       }
     },
   });

--- a/src/components/faktum/faktum-periode/FaktumPeriode.tsx
+++ b/src/components/faktum/faktum-periode/FaktumPeriode.tsx
@@ -20,7 +20,7 @@ interface IDateRange {
   to?: Date | undefined;
 }
 
-export interface IPeriodeFaktumAnswerType {
+export interface IPeriodeFaktumAnswerState {
   fom: string | null;
   tom?: string | null;
 }
@@ -41,7 +41,7 @@ function FaktumPeriodeComponent(
 
   const initialPeriodeValue = { fom: "" };
   const [currentAnswer, setCurrentAnswer] = useState<
-    IQuizPeriodeFaktumAnswerType | IPeriodeFaktumAnswerType
+    IQuizPeriodeFaktumAnswerType | IPeriodeFaktumAnswerState
   >(faktum.svar ?? initialPeriodeValue);
   const [debouncedPeriode, setDebouncedPeriode] = useState(currentAnswer);
   const debouncedChange = useDebouncedCallback(setDebouncedPeriode, 500);
@@ -127,7 +127,7 @@ function FaktumPeriodeComponent(
     setDatePickerIsOpen(!!datepickerProps.open);
   }, [datepickerProps]);
 
-  function saveFaktum(value: IPeriodeFaktumAnswerType) {
+  function saveFaktum(value: IPeriodeFaktumAnswerState) {
     clearErrorMessage();
 
     if (value.fom === "") {

--- a/src/components/faktum/faktum-periode/FaktumPeriode.tsx
+++ b/src/components/faktum/faktum-periode/FaktumPeriode.tsx
@@ -72,7 +72,7 @@ function FaktumPeriodeComponent(
   const { datepickerProps, toInputProps, fromInputProps, setSelected } = UNSAFE_useRangeDatepicker({
     defaultSelected: getDefaultSelectedValue(),
     onRangeChange: (value?: IDateRange) => {
-      // When user clears `from date input field` or types in invalid date format
+      // When user clears `from date input` or types in invalid date format
       if (!value?.from) {
         setCurrentAnswer(initialPeriodeValue);
         debouncedChange(initialPeriodeValue);
@@ -94,30 +94,31 @@ function FaktumPeriodeComponent(
     },
     onValidate: (value) => {
       if (value.from.isEmpty) {
-        // Empty `to date input field` programmatically when user clears `from date input field`
+        // Empty `to date input` programmatically when user clears `from date input`
         setSelected({ from: undefined });
         setCurrentAnswer(initialPeriodeValue);
         debouncedChange(initialPeriodeValue);
         return;
       }
 
-      // When user types in invalid date format on `from date input field`
+      // When user types in invalid date format on `from date input`
       if (!value.from.isEmpty && value.from.isInvalid) {
+        // Set fom to null for validation
         const periode = { ...currentAnswer, fom: null };
         setCurrentAnswer(periode);
         debouncedChange(periode);
         return;
       }
 
-      // Only save fom to state when `to date input field` is empty
-      if (value.to.isEmpty && value.to.isInvalid) {
+      // Only save fom to state when `to date input` is empty
+      if (value.to.isEmpty) {
         const periode = { fom: currentAnswer.fom };
         setCurrentAnswer(periode);
         debouncedChange(periode);
         return;
       }
 
-      // When user types in invalid `to date input field`
+      // When user types in invalid `to date input`
       if (!value.to.isEmpty && value.to.isInvalid) {
         // Set tom to null for validation
         const periode = { ...currentAnswer, tom: null };

--- a/src/components/faktum/faktum-periode/FaktumPeriode.tsx
+++ b/src/components/faktum/faktum-periode/FaktumPeriode.tsx
@@ -58,8 +58,8 @@ function FaktumPeriodeComponent(
 
   // Used to reset current answer to what the backend state is if there is a mismatch
   useEffect(() => {
-    if (faktum.svar && !isFirstRender) {
-      setCurrentAnswer(faktum.svar);
+    if (faktum.svar !== currentAnswer && !isFirstRender) {
+      setCurrentAnswer(faktum.svar ?? initialPeriodeValue);
     }
   }, [faktum.svar]);
 

--- a/src/components/faktum/faktum-periode/FaktumPeriode.tsx
+++ b/src/components/faktum/faktum-periode/FaktumPeriode.tsx
@@ -59,7 +59,7 @@ function FaktumPeriodeComponent(
   // Used to reset current answer to what the backend state is if there is a mismatch
   useEffect(() => {
     if (faktum.svar && !isFirstRender) {
-      setCurrentAnswer({ fom: faktum.svar.fom, tom: faktum.svar.tom });
+      setCurrentAnswer(faktum.svar);
     }
   }, [faktum.svar]);
 

--- a/src/components/faktum/faktum-periode/FaktumPeriode.tsx
+++ b/src/components/faktum/faktum-periode/FaktumPeriode.tsx
@@ -20,6 +20,11 @@ interface IDateRange {
   to?: Date | undefined;
 }
 
+export interface IPeriodeFaktumAnswerType {
+  fom: string | null;
+  tom?: string | null;
+}
+
 export const FaktumPeriode = forwardRef(FaktumPeriodeComponent);
 
 function FaktumPeriodeComponent(
@@ -35,9 +40,9 @@ function FaktumPeriodeComponent(
     useValidateFaktumPeriode(faktum);
 
   const initialPeriodeValue = { fom: "" };
-  const [currentAnswer, setCurrentAnswer] = useState<IQuizPeriodeFaktumAnswerType>(
-    faktum.svar ?? initialPeriodeValue
-  );
+  const [currentAnswer, setCurrentAnswer] = useState<
+    IQuizPeriodeFaktumAnswerType | IPeriodeFaktumAnswerType
+  >(faktum.svar ?? initialPeriodeValue);
   const [debouncedPeriode, setDebouncedPeriode] = useState(currentAnswer);
   const debouncedChange = useDebouncedCallback(setDebouncedPeriode, 500);
 
@@ -47,7 +52,7 @@ function FaktumPeriodeComponent(
 
   useEffect(() => {
     if (!isFirstRender) {
-      saveFaktum(debouncedPeriode);
+      saveFaktum(debouncedPeriode as IQuizPeriodeFaktumAnswerType);
     }
   }, [debouncedPeriode]);
 
@@ -136,7 +141,7 @@ function FaktumPeriodeComponent(
     setDatePickerIsOpen(!!datepickerProps.open);
   }, [datepickerProps]);
 
-  function saveFaktum(value: IQuizPeriodeFaktumAnswerType) {
+  function saveFaktum(value: IPeriodeFaktumAnswerType) {
     clearErrorMessage();
 
     if (value.fom === "") {
@@ -145,7 +150,7 @@ function FaktumPeriodeComponent(
     }
 
     const isValidPeriode = validateAndIsValidPeriode(value);
-    saveFaktumToQuiz(faktum, isValidPeriode ? value : null);
+    saveFaktumToQuiz(faktum, isValidPeriode ? (value as IQuizPeriodeFaktumAnswerType) : null);
   }
 
   return (

--- a/src/components/faktum/faktum-periode/FaktumPeriode.tsx
+++ b/src/components/faktum/faktum-periode/FaktumPeriode.tsx
@@ -72,6 +72,7 @@ function FaktumPeriodeComponent(
   const { datepickerProps, toInputProps, fromInputProps, setSelected } = UNSAFE_useRangeDatepicker({
     defaultSelected: getDefaultSelectedValue(),
     onRangeChange: (value?: IDateRange) => {
+      // When user clears `from date input field` or types in invalid date format
       if (!value?.from) {
         setCurrentAnswer(initialPeriodeValue);
         debouncedChange(initialPeriodeValue);
@@ -93,12 +94,14 @@ function FaktumPeriodeComponent(
     },
     onValidate: (value) => {
       if (value.from.isEmpty) {
+        // Empty `to date input field` programmatically when user clears `from date input field`
         setSelected({ from: undefined });
         setCurrentAnswer(initialPeriodeValue);
         debouncedChange(initialPeriodeValue);
         return;
       }
 
+      // When user types in invalid date format on `from date input field`
       if (!value.from.isEmpty && value.from.isInvalid) {
         const periode = { ...currentAnswer, fom: null };
         setCurrentAnswer(periode);
@@ -106,6 +109,7 @@ function FaktumPeriodeComponent(
         return;
       }
 
+      // Only save fom to state when `to date input field` is empty
       if (value.to.isEmpty && value.to.isInvalid) {
         const periode = { fom: currentAnswer.fom };
         setCurrentAnswer(periode);
@@ -113,7 +117,9 @@ function FaktumPeriodeComponent(
         return;
       }
 
+      // When user types in invalid `to date input field`
       if (!value.to.isEmpty && value.to.isInvalid) {
+        // Set tom to null for validation
         const periode = { ...currentAnswer, tom: null };
         setCurrentAnswer(periode);
         debouncedChange(periode);

--- a/src/components/faktum/faktum-text/FaktumText.test.tsx
+++ b/src/components/faktum/faktum-text/FaktumText.test.tsx
@@ -50,7 +50,7 @@ describe("FaktumText", () => {
     });
   });
 
-  describe.skip("When user inputs an answer", () => {
+  describe("When user inputs an answer", () => {
     test("Should post the answer to the server", async () => {
       const user = userEvent.setup();
       const svar = "Hei på du";

--- a/src/components/faktum/faktum-text/FaktumText.test.tsx
+++ b/src/components/faktum/faktum-text/FaktumText.test.tsx
@@ -73,8 +73,6 @@ describe("FaktumText", () => {
     });
 
     test("Should show error on too longt text", async () => {
-      jest.setTimeout(10000);
-
       const inValidTextLengthMock =
         "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like.";
       const errorTextKey = "validering.text-faktum.for-lang-tekst";

--- a/src/components/faktum/faktum-text/FaktumText.test.tsx
+++ b/src/components/faktum/faktum-text/FaktumText.test.tsx
@@ -50,7 +50,7 @@ describe("FaktumText", () => {
     });
   });
 
-  describe("When user inputs an answer", () => {
+  describe.skip("When user inputs an answer", () => {
     test("Should post the answer to the server", async () => {
       const user = userEvent.setup();
       const svar = "Hei på du";

--- a/src/components/faktum/faktum-text/FaktumText.test.tsx
+++ b/src/components/faktum/faktum-text/FaktumText.test.tsx
@@ -16,6 +16,8 @@ const faktumMockData: IQuizTekstFaktum = {
   roller: [],
 };
 
+jest.setTimeout(10000);
+
 describe("FaktumText", () => {
   // Undo any answer after each test
   beforeEach(() => (faktumMockData.svar = undefined));
@@ -70,7 +72,9 @@ describe("FaktumText", () => {
       });
     });
 
-    test("Should show error on invalid input", async () => {
+    test("Should show error on too longt text", async () => {
+      jest.setTimeout(10000);
+
       const inValidTextLengthMock =
         "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like.";
       const errorTextKey = "validering.text-faktum.for-lang-tekst";

--- a/src/hooks/faktum/useValidateFaktumPeriode.ts
+++ b/src/hooks/faktum/useValidateFaktumPeriode.ts
@@ -9,7 +9,6 @@ interface IUseValidateFaktumPeriode {
   validateAndIsValidPeriode: (svar: IQuizPeriodeFaktumAnswerType) => boolean;
   fomErrorMessage: string | undefined;
   tomErrorMessage: string | undefined;
-  getTomIsBeforeTomErrorMessage: () => string;
   clearErrorMessage: () => void;
 }
 
@@ -28,64 +27,55 @@ export function useValidateFaktumPeriode(faktum: QuizFaktum): IUseValidateFaktum
   function validateAndIsValidPeriode(svar: IQuizPeriodeFaktumAnswerType) {
     const { fom, tom } = svar;
 
-    if (!fom) {
+    if (fom === null) {
       setFomErrorMessage(getAppText("validering.ugyldig-dato"));
       return false;
     }
 
-    if (!tom) {
+    if (tom === null) {
       setTomErrorMessage(getAppText("validering.ugyldig-dato"));
       return false;
     }
 
     const fomDateIsInfuture = isFuture(new Date(fom));
-    const isValidFromDate = isWithinValidYearRange(new Date(tom));
+    const isValidFromDate = isWithinValidYearRange(new Date(fom));
 
-    setFomErrorMessage(undefined);
-    setTomErrorMessage(undefined);
+      setFomErrorMessage(undefined);
+      setTomErrorMessage(undefined);
 
-    const specialCase =
-      faktum.beskrivendeId === "faktum.arbeidsforhold.permittert-periode" ||
-      faktum.beskrivendeId === "faktum.arbeidsforhold.naar-var-lonnsplikt-periode";
+      const specialCase =
+        faktum.beskrivendeId === "faktum.arbeidsforhold.permittert-periode" ||
+        faktum.beskrivendeId === "faktum.arbeidsforhold.naar-var-lonnsplikt-periode";
+
+      let isValidPeriode = true;
 
     // Future date is allowed on those two special cases
     if (specialCase && !isValidFromDate) {
       setFomErrorMessage(getAppText("validering.ugyldig-dato"));
-      return false;
+      isValidPeriode = false;
     }
 
     if (fomDateIsInfuture && !specialCase) {
       setFomErrorMessage(getAppText("validering.fremtidig-dato"));
-      return false;
+      isValidPeriode = false;
     }
 
     if (fomDateIsInfuture && faktum.beskrivendeId === "faktum.arbeidsforhold.varighet") {
       setFomErrorMessage(getAppText("validering.arbeidsforhold.varighet-fra"));
-      return false;
+      isValidPeriode = false;
     }
 
     if (!isValidFromDate) {
       setFomErrorMessage(getAppText("validering.ugyldig-dato"));
-      return false;
-    }
-
-    if (!tom) {
-      setTomErrorMessage(undefined);
-      return true;
+      isValidPeriode = false;
     }
 
     if (tom && !isWithinValidYearRange(new Date(tom))) {
       setTomErrorMessage(getAppText("validering.ugyldig-dato"));
-      return false;
+      isValidPeriode = false;
     }
 
-    return true;
-  }
-
-  function getTomIsBeforeTomErrorMessage() {
-    return faktum.beskrivendeId === "faktum.arbeidsforhold.varighet"
-      ? getAppText("validering.arbeidsforhold.varighet-til")
-      : getAppText("validering.sluttdato-kan-ikke-vaere-foor-dato");
+    return isValidPeriode;
   }
 
   function clearErrorMessage() {
@@ -97,7 +87,6 @@ export function useValidateFaktumPeriode(faktum: QuizFaktum): IUseValidateFaktum
     validateAndIsValidPeriode,
     fomErrorMessage,
     tomErrorMessage,
-    getTomIsBeforeTomErrorMessage,
     clearErrorMessage,
   };
 }

--- a/src/hooks/faktum/useValidateFaktumPeriode.ts
+++ b/src/hooks/faktum/useValidateFaktumPeriode.ts
@@ -1,13 +1,13 @@
 import { isFuture } from "date-fns";
 import { useEffect, useState } from "react";
-import { IPeriodeFaktumAnswerType } from "../../components/faktum/faktum-periode/FaktumPeriode";
+import { IPeriodeFaktumAnswerState } from "../../components/faktum/faktum-periode/FaktumPeriode";
 import { isWithinValidYearRange } from "../../components/faktum/validation/validations.utils";
 import { useSanity } from "../../context/sanity-context";
 import { useValidation } from "../../context/validation-context";
 import { QuizFaktum } from "../../types/quiz.types";
 
 interface IUseValidateFaktumPeriode {
-  validateAndIsValidPeriode: (svar: IPeriodeFaktumAnswerType) => boolean;
+  validateAndIsValidPeriode: (svar: IPeriodeFaktumAnswerState) => boolean;
   fomErrorMessage: string | undefined;
   tomErrorMessage: string | undefined;
   clearErrorMessage: () => void;
@@ -25,7 +25,7 @@ export function useValidateFaktumPeriode(faktum: QuizFaktum): IUseValidateFaktum
     );
   }, [unansweredFaktumId]);
 
-  function validateAndIsValidPeriode(svar: IPeriodeFaktumAnswerType) {
+  function validateAndIsValidPeriode(svar: IPeriodeFaktumAnswerState) {
     const { fom, tom } = svar;
 
     if (fom === null) {

--- a/src/hooks/faktum/useValidateFaktumPeriode.ts
+++ b/src/hooks/faktum/useValidateFaktumPeriode.ts
@@ -1,12 +1,13 @@
 import { isFuture } from "date-fns";
 import { useEffect, useState } from "react";
+import { IPeriodeFaktumAnswerType } from "../../components/faktum/faktum-periode/FaktumPeriode";
 import { isWithinValidYearRange } from "../../components/faktum/validation/validations.utils";
 import { useSanity } from "../../context/sanity-context";
 import { useValidation } from "../../context/validation-context";
-import { IQuizPeriodeFaktumAnswerType, QuizFaktum } from "../../types/quiz.types";
+import { QuizFaktum } from "../../types/quiz.types";
 
 interface IUseValidateFaktumPeriode {
-  validateAndIsValidPeriode: (svar: IQuizPeriodeFaktumAnswerType) => boolean;
+  validateAndIsValidPeriode: (svar: IPeriodeFaktumAnswerType) => boolean;
   fomErrorMessage: string | undefined;
   tomErrorMessage: string | undefined;
   clearErrorMessage: () => void;
@@ -24,7 +25,7 @@ export function useValidateFaktumPeriode(faktum: QuizFaktum): IUseValidateFaktum
     );
   }, [unansweredFaktumId]);
 
-  function validateAndIsValidPeriode(svar: IQuizPeriodeFaktumAnswerType) {
+  function validateAndIsValidPeriode(svar: IPeriodeFaktumAnswerType) {
     const { fom, tom } = svar;
 
     if (fom === null) {
@@ -40,14 +41,14 @@ export function useValidateFaktumPeriode(faktum: QuizFaktum): IUseValidateFaktum
     const fomDateIsInfuture = isFuture(new Date(fom));
     const isValidFromDate = isWithinValidYearRange(new Date(fom));
 
-      setFomErrorMessage(undefined);
-      setTomErrorMessage(undefined);
+    setFomErrorMessage(undefined);
+    setTomErrorMessage(undefined);
 
-      const specialCase =
-        faktum.beskrivendeId === "faktum.arbeidsforhold.permittert-periode" ||
-        faktum.beskrivendeId === "faktum.arbeidsforhold.naar-var-lonnsplikt-periode";
+    const specialCase =
+      faktum.beskrivendeId === "faktum.arbeidsforhold.permittert-periode" ||
+      faktum.beskrivendeId === "faktum.arbeidsforhold.naar-var-lonnsplikt-periode";
 
-      let isValidPeriode = true;
+    let isValidPeriode = true;
 
     // Future date is allowed on those two special cases
     if (specialCase && !isValidFromDate) {

--- a/src/types/quiz.types.ts
+++ b/src/types/quiz.types.ts
@@ -89,7 +89,7 @@ export interface IQuizSeksjon {
 }
 
 export interface IQuizPeriodeFaktumAnswerType {
-  fom: string;
+  fom: string | null;
   tom?: string | null;
 }
 

--- a/src/types/quiz.types.ts
+++ b/src/types/quiz.types.ts
@@ -89,8 +89,8 @@ export interface IQuizSeksjon {
 }
 
 export interface IQuizPeriodeFaktumAnswerType {
-  fom: string | null;
-  tom?: string | null;
+  fom: string;
+  tom?: string;
 }
 
 export type QuizFaktumSvarType =


### PR DESCRIPTION
Det er en feil i prod, når man velge en dato -> slette dato -> og skrive en ugyldig dato format får vi ikke opp en valideringsfeilmelding. Det er fordi at både ugyldig dato format og tomt felt er `undefined`. 

Denne løsningen legge vi inn to forskjellige state for dato, `undefined` for tomt felt og `null` og ugyldig dato format.