### PR TITLE
Fikser navigasjonsknapper

### DIFF
--- a/src/views/dokumentasjon/Dokumentasjon.tsx
+++ b/src/views/dokumentasjon/Dokumentasjon.tsx
@@ -21,6 +21,7 @@ import { NoSessionModal } from "../../components/no-session-modal/NoSessionModal
 import styles from "./Dokumentasjon.module.css";
 import { tidBruktSiden, tidStart, trackDokumentasjonLastetOpp } from "../../amplitude.tracking";
 import { DOKUMENTKRAV_SVAR_SEND_NAA } from "../../constants";
+import { useQuiz } from "../../context/quiz-context";
 
 export function Dokumentasjon() {
   const router = useRouter();
@@ -28,6 +29,7 @@ export function Dokumentasjon() {
   const { scrollIntoView } = useScrollIntoView();
   const { getAppText, getInfosideText } = useSanity();
   const { totalSteps, documentationStep } = useProgressBarSteps();
+  const { soknadState } = useQuiz();
   const { dokumentkravList, getFirstUnansweredDokumentkrav } = useDokumentkrav();
   const [showBundleErrorModal, setShowBundleErrorModal] = useState(false);
   const [isNavigating, setIsNavigating] = useState(false);
@@ -140,7 +142,7 @@ export function Dokumentasjon() {
       })}
 
       <nav className="navigation-container">
-        <Link href={`/soknad/${uuid}/kvittering`} passHref>
+        <Link href={`/soknad/${uuid}?seksjon=${soknadState.seksjoner.length}`} passHref>
           <Button as="a" variant="secondary">
             {getAppText("soknad.knapp.forrige-steg")}
           </Button>

--- a/src/views/summary/Summary.tsx
+++ b/src/views/summary/Summary.tsx
@@ -94,8 +94,7 @@ export function Summary(props: IProps) {
     if (dokumentkravList.krav.length > 0) {
       router.push(`/soknad/${router.query.uuid}/dokumentasjon`);
     } else {
-      const lastSection = soknadState.seksjoner.length;
-      router.push(`/soknad/${router.query.uuid}?seksjon=${lastSection}`);
+      router.push(`/soknad/${router.query.uuid}?seksjon=${soknadState.seksjoner.length}`);
     }
   }
 

--- a/src/views/summary/Summary.tsx
+++ b/src/views/summary/Summary.tsx
@@ -42,7 +42,7 @@ export function Summary(props: IProps) {
 
   const [consentGiven, setConsentGiven] = useState(false);
   const consentRef = useRef(null);
-  const [navigating, setIsNagivating] = useState(false);
+  const [navigating, setIsNavigating] = useState(false);
   const [showConsentValidation, setShowConsentValidation] = useState(false);
   const [showSoknadNotCompleteError, setshowSoknadNotCompleteError] = useState(false);
   const [finishSoknad, finishSoknadStatus] = usePutRequest<IFerdigstillBody>(`soknad/ferdigstill`);
@@ -89,9 +89,14 @@ export function Summary(props: IProps) {
     finishSoknad({ uuid, locale });
   }
 
-  function navigateToDocumentation() {
-    setIsNagivating(true);
-    router.push(`/soknad/${router.query.uuid}/dokumentasjon`);
+  function navigateToPreviousStep() {
+    setIsNavigating(true);
+    if (dokumentkravList.krav.length > 0) {
+      router.push(`/soknad/${router.query.uuid}/dokumentasjon`);
+    } else {
+      const lastSection = soknadState.seksjoner.length;
+      router.push(`/soknad/${router.query.uuid}?seksjon=${lastSection}`);
+    }
   }
 
   useEffect(() => {
@@ -208,7 +213,7 @@ export function Summary(props: IProps) {
       <nav className="navigation-container">
         <Button
           variant={"secondary"}
-          onClick={() => navigateToDocumentation()}
+          onClick={() => navigateToPreviousStep()}
           icon={<Left />}
           loading={navigating}
         >


### PR DESCRIPTION
Når bruker ikke hadde dokumentkrav og trykket tilbake på oppsummeringssiden kom vedkommende ikke noe vei, de ble stående på oppsummeringssiden. Opprinnelig var det tenkt at alle skulle via dokumentasjonssiden, men siden vi nå redirecter brukere uten dokumentkrav videre til oppsummeringssiden trenger vi ekstra logikk for å komme tilbake til siste seksjon i søknaden.

Tilbake-knappen på dokumentasjonssiden var også en kuriositet, den lenket til kvitteringen, noe som ble helt feil. Kvitteringssiden redirecter tilbake til søknadens start når søknaden ikke er ferdig, så brukeren så ingen feilside. Lenker nå til riktig siste seksjon i søknaden.