### PR TITLE
Første API-tester, lagring av faktum og sletting av fil i dokumentkrav

### DIFF
--- a/src/__mocks__/mockGetSession.ts
+++ b/src/__mocks__/mockGetSession.ts
@@ -1,0 +1,8 @@
+export function mockGetSession() {
+  return {
+    token:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJwaWQiOiIxMjMxMjMxMjMifQ.XdPmoIvLFmgz51eH_05WBNOllgWEtp9kYHkWAHqMwEc",
+    apiToken: async () => "access_token",
+    expiresIn: 123,
+  };
+}

--- a/src/__tests__/pages/api/documentation/file/delete.test.ts
+++ b/src/__tests__/pages/api/documentation/file/delete.test.ts
@@ -6,21 +6,12 @@ import { createMocks } from "node-mocks-http";
 import deleteFileHandler, {
   IDeleteFileBody,
 } from "../../../../../pages/api/documentation/file/delete";
-import { getSession as _getSession } from "../../../../../auth.utils";
+import { mockGetSession } from "../../../../../__mocks__/mockGetSession";
 import fetch from "jest-fetch-mock";
 
-jest.mock("../../../../../auth.utils");
-const getSession = _getSession as jest.MockedFunction<typeof _getSession>;
-
-beforeEach(() => {
-  getSession.mockResolvedValue({
-    token:
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJwaWQiOiIxMjMxMjMxMjMifQ.XdPmoIvLFmgz51eH_05WBNOllgWEtp9kYHkWAHqMwEc",
-    apiToken: async () => "access_token",
-    expiresIn: 123,
-  });
-});
-afterEach(() => getSession.mockClear());
+jest.mock("../../../../../auth.utils", () => ({
+  getSession: () => mockGetSession(),
+}));
 
 beforeEach(() => {
   fetch.enableMocks();

--- a/src/__tests__/pages/api/documentation/file/delete.test.ts
+++ b/src/__tests__/pages/api/documentation/file/delete.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+
+import { createMocks } from "node-mocks-http";
+import deleteFileHandler, {
+  IDeleteFileBody,
+} from "../../../../../pages/api/documentation/file/delete";
+import { getSession as _getSession } from "../../../../../auth.utils";
+import fetch from "jest-fetch-mock";
+
+jest.mock("../../../../../auth.utils");
+const getSession = _getSession as jest.MockedFunction<typeof _getSession>;
+
+beforeEach(() => {
+  getSession.mockResolvedValue({
+    token:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJwaWQiOiIxMjMxMjMxMjMifQ.XdPmoIvLFmgz51eH_05WBNOllgWEtp9kYHkWAHqMwEc",
+    apiToken: async () => "access_token",
+    expiresIn: 123,
+  });
+});
+afterEach(() => getSession.mockClear());
+
+beforeEach(() => {
+  fetch.enableMocks();
+});
+
+afterEach(() => {
+  fetch.mockReset();
+});
+
+const deleteFileMockData: IDeleteFileBody = {
+  uuid: "1234",
+  dokumentkravId: "5678",
+  filsti: "soknad-uuid/faktumId/file-id-1",
+};
+
+describe("/api/documentation/file/delete", () => {
+  test("Should delete a documentation file", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ ok: true }), { status: 200 }], // Delete file from dp-soknad
+      [JSON.stringify({ ok: true }), { status: 200 }] // Delete file from dp-mellomlagring
+    );
+
+    const { req, res } = createMocks({
+      method: "DELETE",
+      body: deleteFileMockData,
+    });
+
+    await deleteFileHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData()).toEqual("OK");
+  });
+
+  test("Should return error if deleting the file from dp-soknad fails", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ ok: false }), { status: 500 }] // Delete file from dp-soknad
+    );
+
+    const { req, res } = createMocks({
+      method: "DELETE",
+      body: deleteFileMockData,
+    });
+
+    await deleteFileHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getData()).toEqual("Internal Server Error");
+  });
+
+  test("Should return 200 OK if deleting the file from dp-mellomlagring fails, but dp-soknad works", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ ok: true }), { status: 200 }], // Delete file from dp-soknad
+      [JSON.stringify({ status: 500, statusText: "Something bad happened" }), { status: 500 }] // Delete file from dp-mellomlagring
+    );
+
+    const { req, res } = createMocks({
+      method: "DELETE",
+      body: deleteFileMockData,
+    });
+
+    await deleteFileHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData()).toEqual("OK");
+  });
+});

--- a/src/__tests__/pages/api/documentation/svar.test.ts
+++ b/src/__tests__/pages/api/documentation/svar.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment node
+ */
+
+import { createMocks } from "node-mocks-http";
+import { mockGetSession } from "../../../../__mocks__/mockGetSession";
+import fetch from "jest-fetch-mock";
+import svarHandler, { IDokumentkravSvarBody } from "../../../../pages/api/documentation/svar";
+import { DOKUMENTKRAV_SVAR_SEND_NAA } from "../../../../constants";
+import { mockDokumentkravList } from "../../../../localhost-data/dokumentkrav-list";
+
+jest.mock("../../../../auth.utils", () => ({
+  getSession: () => mockGetSession(),
+}));
+
+beforeEach(() => {
+  fetch.enableMocks();
+});
+
+afterEach(() => {
+  fetch.mockReset();
+});
+
+const dokumentkravSvarMockdata: IDokumentkravSvarBody = {
+  uuid: "1234",
+  dokumentkravId: "5678",
+  dokumentkravSvar: {
+    svar: DOKUMENTKRAV_SVAR_SEND_NAA,
+    begrunnelse: "",
+  },
+};
+
+describe("/api/documentation/svar", () => {
+  test("Should post a dokumentkrav svar", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ ok: true }), { status: 200 }], // Post the answer to dp-soknad
+      [JSON.stringify(mockDokumentkravList), { status: 200 }] // Get new state on all dokumentkrav from dp-soknad
+    );
+
+    const { req, res } = createMocks({
+      method: "PUT",
+      body: dokumentkravSvarMockdata,
+    });
+
+    await svarHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData()).toEqual(mockDokumentkravList);
+  });
+
+  test("Should return error if posting the answer to dp-soknad fails", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ ok: false }), { status: 500 }], // Post the answer to dp-soknad
+      [JSON.stringify(mockDokumentkravList), { status: 200 }] // Get new state on all dokumentkrav from dp-soknad
+    );
+
+    const { req, res } = createMocks({
+      method: "PUT",
+      body: dokumentkravSvarMockdata,
+    });
+
+    await svarHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getData()).toEqual("Internal Server Error");
+  });
+
+  test("Should return 200 OK if getting the new dokumentkrav state fails after posting the answer", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ ok: true }), { status: 200 }], // Post the answer to dp-soknad
+      [JSON.stringify({ status: 500, statusText: "Something bad happened" }), { status: 500 }] // Get the new state on all dokumentkrav from dp-soknad
+    );
+
+    const { req, res } = createMocks({
+      method: "PUT",
+      body: dokumentkravSvarMockdata,
+    });
+
+    await svarHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData()).toEqual("OK");
+  });
+});

--- a/src/__tests__/pages/api/soknad/delete.test.ts
+++ b/src/__tests__/pages/api/soknad/delete.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment node
+ */
+
+import { createMocks } from "node-mocks-http";
+import { mockGetSession } from "../../../../__mocks__/mockGetSession";
+import fetch from "jest-fetch-mock";
+import deleteHandler, { IDeleteSoknadBody } from "../../../../pages/api/soknad/delete";
+
+jest.mock("../../../../auth.utils", () => ({
+  getSession: () => mockGetSession(),
+}));
+
+beforeEach(() => {
+  fetch.enableMocks();
+});
+
+afterEach(() => {
+  fetch.mockReset();
+});
+
+const deleteSoknadMockdata: IDeleteSoknadBody = {
+  uuid: "1234",
+};
+
+describe("/api/soknad/delete", () => {
+  test("Should delete an application", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ ok: true }), { status: 200 }] // Delete from dp-soknad
+    );
+
+    const { req, res } = createMocks({
+      method: "DELETE",
+      body: deleteSoknadMockdata,
+    });
+
+    await deleteHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData()).toEqual("OK");
+  });
+
+  test("Should return error if deleting the application fails", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ ok: false }), { status: 500 }] // Delete application from dp-soknad
+    );
+
+    const { req, res } = createMocks({
+      method: "DELETE",
+      body: deleteSoknadMockdata,
+    });
+
+    await deleteHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getData()).toEqual("Internal Server Error");
+  });
+});

--- a/src/__tests__/pages/api/soknad/faktum/save.test.ts
+++ b/src/__tests__/pages/api/soknad/faktum/save.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment node
+ */
+
+import { createMocks } from "node-mocks-http";
+import saveFaktumHandler, { ISaveFaktumBody } from "../../../../../pages/api/soknad/faktum/save";
+import { getSession as _getSession } from "../../../../../auth.utils";
+import fetch from "jest-fetch-mock";
+import { QuizFaktum } from "../../../../../types/quiz.types";
+import { mockNeste } from "../../../../../localhost-data/mock-neste";
+
+jest.mock("../../../../../auth.utils");
+const getSession = _getSession as jest.MockedFunction<typeof _getSession>;
+
+beforeEach(() => {
+  getSession.mockResolvedValue({
+    token:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJwaWQiOiIxMjMxMjMxMjMifQ.XdPmoIvLFmgz51eH_05WBNOllgWEtp9kYHkWAHqMwEc",
+    apiToken: async () => "access_token",
+    expiresIn: 123,
+  });
+});
+afterEach(() => getSession.mockClear());
+
+beforeEach(() => {
+  fetch.enableMocks();
+});
+
+afterEach(() => {
+  fetch.mockReset();
+});
+
+const faktumMockData: QuizFaktum = {
+  id: "10001",
+  svar: "faktum.mottatt-dagpenger-siste-12-mnd.svar.nei",
+  type: "envalg",
+  readOnly: false,
+  gyldigeValg: [
+    "faktum.mottatt-dagpenger-siste-12-mnd.svar.ja",
+    "faktum.mottatt-dagpenger-siste-12-mnd.svar.nei",
+    "faktum.mottatt-dagpenger-siste-12-mnd.svar.vet-ikke",
+  ],
+  beskrivendeId: "faktum.mottatt-dagpenger-siste-12-mnd",
+  sannsynliggjoresAv: [],
+  roller: [],
+};
+
+const saveFaktumMockData: ISaveFaktumBody = {
+  faktum: faktumMockData,
+  svar: faktumMockData.gyldigeValg[0],
+  uuid: "1234",
+};
+
+describe("/api/soknad/faktum/save", () => {
+  test("Should post answer and get new application state back", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ ok: true }), { status: 200 }], // Post answer "send later"
+      [JSON.stringify(mockNeste), { status: 200 }] // Fetch new application state
+    );
+
+    const { req, res } = createMocks({
+      method: "PUT",
+      body: saveFaktumMockData,
+    });
+
+    await saveFaktumHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData()).toEqual(mockNeste);
+  });
+
+  test("Should return error if answering the question fails", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ ok: false }), { status: 500 }], // Post answer "send later"
+      [JSON.stringify(mockNeste), { status: 200 }] // Fetch new application state
+    );
+
+    const { req, res } = createMocks({
+      method: "PUT",
+      body: saveFaktumMockData,
+    });
+
+    await saveFaktumHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getData()).toEqual("Internal Server Error");
+  });
+
+  test("Should return error if getting the new application state fails", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ ok: true }), { status: 200 }], // Post answer "send later"
+      [JSON.stringify({ status: 500, statusText: "Something bad happened" }), { status: 500 }] // Fetch new application state
+    );
+
+    const { req, res } = createMocks({
+      method: "PUT",
+      body: saveFaktumMockData,
+    });
+
+    await saveFaktumHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getData()).toEqual("Internal Server Error");
+  });
+});

--- a/src/__tests__/pages/api/soknad/faktum/save.test.ts
+++ b/src/__tests__/pages/api/soknad/faktum/save.test.ts
@@ -4,23 +4,14 @@
 
 import { createMocks } from "node-mocks-http";
 import saveFaktumHandler, { ISaveFaktumBody } from "../../../../../pages/api/soknad/faktum/save";
-import { getSession as _getSession } from "../../../../../auth.utils";
 import fetch from "jest-fetch-mock";
 import { QuizFaktum } from "../../../../../types/quiz.types";
 import { mockNeste } from "../../../../../localhost-data/mock-neste";
+import { mockGetSession } from "../../../../../__mocks__/mockGetSession";
 
-jest.mock("../../../../../auth.utils");
-const getSession = _getSession as jest.MockedFunction<typeof _getSession>;
-
-beforeEach(() => {
-  getSession.mockResolvedValue({
-    token:
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJwaWQiOiIxMjMxMjMxMjMifQ.XdPmoIvLFmgz51eH_05WBNOllgWEtp9kYHkWAHqMwEc",
-    apiToken: async () => "access_token",
-    expiresIn: 123,
-  });
-});
-afterEach(() => getSession.mockClear());
+jest.mock("../../../../../auth.utils", () => ({
+  getSession: () => mockGetSession(),
+}));
 
 beforeEach(() => {
   fetch.enableMocks();

--- a/src/__tests__/pages/api/soknad/ferdigstill.test.ts
+++ b/src/__tests__/pages/api/soknad/ferdigstill.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment node
+ */
+
+import { createMocks } from "node-mocks-http";
+import { mockGetSession } from "../../../../__mocks__/mockGetSession";
+import fetch from "jest-fetch-mock";
+import ferdigstillHandler, { IFerdigstillBody } from "../../../../pages/api/soknad/ferdigstill";
+import { mockSanityTexts } from "../../../../__mocks__/MockContext";
+
+jest.mock("../../../../auth.utils", () => ({
+  getSession: () => mockGetSession(),
+}));
+
+jest.mock("../../../../../sanity-client", () => ({
+  sanityClient: {
+    fetch: () => Promise.resolve(mockSanityTexts),
+  },
+}));
+
+beforeEach(() => {
+  fetch.enableMocks();
+});
+
+afterEach(() => {
+  fetch.mockReset();
+});
+
+const ferdigstillMockData: IFerdigstillBody = {
+  uuid: "1234",
+  locale: "nb",
+};
+
+describe("/api/soknad/ferdigstill", () => {
+  test("Should send an application", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ ok: true }), { status: 200 }] // Response from dp-soknad
+    );
+
+    const { req, res } = createMocks({
+      method: "PUT",
+      body: ferdigstillMockData,
+    });
+
+    await ferdigstillHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData()).toEqual("OK");
+  });
+
+  test("Should return error if sending in the application fails", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ ok: false }), { status: 500 }] // Response from dp-soknad on error
+    );
+
+    const { req, res } = createMocks({
+      method: "PUT",
+      body: ferdigstillMockData,
+    });
+
+    await ferdigstillHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getData()).toEqual("Internal Server Error");
+  });
+});

--- a/src/__tests__/pages/api/soknad/uuid.test.ts
+++ b/src/__tests__/pages/api/soknad/uuid.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment node
+ */
+
+import { createMocks } from "node-mocks-http";
+import { mockGetSession } from "../../../../__mocks__/mockGetSession";
+import fetch from "jest-fetch-mock";
+import uuidHandler from "../../../../pages/api/soknad/uuid";
+
+jest.mock("../../../../auth.utils", () => ({
+  getSession: () => mockGetSession(),
+}));
+
+beforeEach(() => {
+  fetch.enableMocks();
+});
+
+afterEach(() => {
+  fetch.mockReset();
+});
+
+describe("/api/soknad/uuid", () => {
+  test("Should get a new uuid to start an application", async () => {
+    fetch.mockResponses(
+      ["12345", { status: 200 }] // Response from dp-soknad
+    );
+
+    const { req, res } = createMocks({
+      method: "POST",
+    });
+
+    await uuidHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData()).toEqual("12345");
+  });
+
+  test("Should return error if getting a new uuid fails", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ ok: false }), { status: 500 }] // Response from dp-soknad on error
+    );
+
+    const { req, res } = createMocks({
+      method: "POST",
+    });
+
+    await uuidHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getData()).toEqual("Internal Server Error");
+  });
+});

--- a/src/components/file-list/FileList.test.tsx
+++ b/src/components/file-list/FileList.test.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { render, screen, fireEvent, waitForElementToBeRemoved } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { mockDokumentkravList } from "../../localhost-data/dokumentkrav-list";
+import fetch from "jest-fetch-mock";
+import { MockContext } from "../../__mocks__/MockContext";
+import { FileUploader } from "../file-uploader/FileUploader";
+import { FileList } from "../../components/file-list/FileList";
+import { useFileUploader } from "../../hooks/useFileUploader";
+
+const FileTestContainer = () => {
+  // Need to have a custom hook here to test the dynamic between FileUploader and FileList
+  const { handleUploadedFiles, uploadedFiles } = useFileUploader(
+    mockDokumentkravList.krav[0].filer
+  );
+
+  return (
+    <>
+      <FileUploader
+        dokumentkrav={mockDokumentkravList.krav[0]}
+        maxFileSize={100}
+        handleUploadedFiles={handleUploadedFiles}
+      />
+      <FileList
+        dokumentkravId={mockDokumentkravList.krav[0].id}
+        uploadedFiles={uploadedFiles}
+        handleUploadedFiles={handleUploadedFiles}
+      />
+    </>
+  );
+};
+
+describe("FileList", () => {
+  beforeEach(() => {
+    fetch.enableMocks();
+  });
+
+  afterEach(() => {
+    fetch.mockReset();
+  });
+
+  describe("Upload file", () => {
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    function simulateFileUpload(screen: any, array: File[]) {
+      const inputEl = screen.getByTestId("dropzone");
+
+      Object.defineProperty(inputEl, "files", {
+        value: array,
+      });
+
+      fireEvent.drop(inputEl);
+    }
+
+    describe("When user selects a valid file to upload", () => {
+      beforeEach(() => {
+        fetch.mockResponse(
+          JSON.stringify({
+            ok: true,
+            urn: "1234",
+            filnavn: "image.jpg",
+            filsti: "1234/5678",
+          })
+        );
+      });
+
+      it("Should show the file after upload", async () => {
+        render(
+          <MockContext>
+            <FileTestContainer />
+          </MockContext>
+        );
+
+        const file = new File(["file"], "image.jpg", {
+          type: "image/jpg",
+        });
+
+        simulateFileUpload(screen, [file]);
+
+        expect(await screen.findByText(file.name)).toBeInTheDocument();
+        expect(fetch.mock.calls.length).toEqual(1);
+      });
+    });
+
+    it("Should show info on invalid files, and not upload anything", async () => {
+      render(
+        <MockContext>
+          <FileTestContainer />
+        </MockContext>
+      );
+
+      const file = new File(["file"], "image.json", {
+        type: "application/json",
+      });
+
+      simulateFileUpload(screen, [file]);
+
+      expect(await screen.findByText(file.name)).toBeInTheDocument();
+      expect(
+        await screen.findByText("filopplaster.feilmelding.format-storrelse-beskrivelse")
+      ).toBeInTheDocument();
+      expect(fetch.mock.calls.length).toEqual(0);
+    });
+  });
+
+  describe("Delete uploaded file", () => {
+    it("Should delete an uploaded file and remove it from the view", async () => {
+      const fileToTest = mockDokumentkravList.krav[0].filer[0];
+
+      // Request to delete file
+      fetch.mockResponseOnce(
+        JSON.stringify({
+          ok: true,
+        })
+      );
+
+      const user = userEvent.setup();
+
+      render(
+        <MockContext>
+          <FileTestContainer />
+        </MockContext>
+      );
+
+      const deleteButton = screen.getByRole("button", { description: fileToTest.filnavn });
+      user.click(deleteButton);
+
+      await waitForElementToBeRemoved(deleteButton);
+      expect(fetch.mock.calls.length).toEqual(1);
+    });
+  });
+});

--- a/src/pages/api/soknad/delete.ts
+++ b/src/pages/api/soknad/delete.ts
@@ -32,7 +32,7 @@ async function deleteHandler(req: NextApiRequest, res: NextApiResponse) {
       return res.status(deleteSoknadResponse.status).send(deleteSoknadResponse.statusText);
     }
 
-    return res.json(deleteSoknadResponse);
+    return res.status(deleteSoknadResponse.status).send(deleteSoknadResponse.statusText);
   } catch (error) {
     const message = getErrorMessage(error);
     logRequestError(message, uuid);

--- a/src/pages/api/soknad/ferdigstill.ts
+++ b/src/pages/api/soknad/ferdigstill.ts
@@ -47,7 +47,7 @@ async function ferdigstillHandler(req: NextApiRequest, res: NextApiResponse) {
       logRequestError(ferdigstillResponse.statusText, uuid);
       return res.status(ferdigstillResponse.status).send(ferdigstillResponse.statusText);
     }
-    return res.status(ferdigstillResponse.status).end();
+    return res.status(ferdigstillResponse.status).end(ferdigstillResponse.statusText);
   } catch (error: unknown) {
     const message = getErrorMessage(error);
     logRequestError(message, uuid);

--- a/src/pages/api/soknad/ferdigstill.ts
+++ b/src/pages/api/soknad/ferdigstill.ts
@@ -47,7 +47,7 @@ async function ferdigstillHandler(req: NextApiRequest, res: NextApiResponse) {
       logRequestError(ferdigstillResponse.statusText, uuid);
       return res.status(ferdigstillResponse.status).send(ferdigstillResponse.statusText);
     }
-    return res.status(ferdigstillResponse.status).end(ferdigstillResponse.statusText);
+    return res.status(ferdigstillResponse.status).send(ferdigstillResponse.statusText);
   } catch (error: unknown) {
     const message = getErrorMessage(error);
     logRequestError(message, uuid);

--- a/src/views/dokumentasjon/DokumentkravItem.test.tsx
+++ b/src/views/dokumentasjon/DokumentkravItem.test.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import { render, waitFor, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DOKUMENTKRAV_SVAR_SENDER_IKKE, DOKUMENTKRAV_SVAR_SEND_NAA } from "../../constants";
+import { mockDokumentkravList } from "../../localhost-data/dokumentkrav-list";
+import fetch from "jest-fetch-mock";
+import { MockContext } from "../../__mocks__/MockContext";
+import { DokumentkravItem } from "./DokumentkravItem";
+import { GyldigDokumentkravSvar } from "../../types/documentation.types";
+
+describe("DokumentkravItem", () => {
+  beforeEach(() => {
+    fetch.enableMocks();
+  });
+
+  afterEach(() => {
+    fetch.mockReset();
+  });
+
+  test("Should show dokumentkrav title", async () => {
+    render(
+      <MockContext>
+        <DokumentkravItem
+          dokumentkrav={mockDokumentkravList.krav[0]}
+          hasBundleError={false}
+          hasUnansweredError={false}
+          resetError={jest.fn()}
+        />
+      </MockContext>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading")).toHaveTextContent(
+        mockDokumentkravList.krav[0].beskrivendeId
+      );
+    });
+  });
+
+  test("Should show dokumentkrav title and employer name for arbeidsforhold dokumentkrav", async () => {
+    render(
+      <MockContext dokumentkrav={mockDokumentkravList.krav}>
+        <DokumentkravItem
+          dokumentkrav={mockDokumentkravList.krav[0]}
+          hasBundleError={false}
+          hasUnansweredError={false}
+          resetError={jest.fn()}
+        />
+      </MockContext>
+    );
+
+    await waitFor(() => {
+      const dokumentkravTitle = `${mockDokumentkravList.krav[0].beskrivendeId} (${mockDokumentkravList.krav[0].beskrivelse})`;
+      expect(screen.getByRole("heading")).toHaveTextContent(dokumentkravTitle);
+    });
+  });
+
+  test("Should post answer when user answers dokumentkrav question", async () => {
+    fetch.mockResponses(
+      [JSON.stringify(mockDokumentkravList), { status: 200 }] // New dokumentkrav state from dp-soknad when user posts answer
+    );
+
+    const testDokumentkrav = { ...mockDokumentkravList.krav[0], svar: undefined };
+
+    const user = userEvent.setup();
+
+    render(
+      <MockContext dokumentkrav={[testDokumentkrav]}>
+        <DokumentkravItem
+          dokumentkrav={testDokumentkrav}
+          hasBundleError={false}
+          hasUnansweredError={false}
+          resetError={jest.fn()}
+        />
+      </MockContext>
+    );
+
+    await user.click(screen.getByLabelText(DOKUMENTKRAV_SVAR_SEND_NAA));
+
+    await waitFor(() => {
+      expect(fetch.mock.calls.length).toEqual(1);
+    });
+  });
+
+  test("Should show upload component when question has a specific answer", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MockContext dokumentkrav={mockDokumentkravList.krav}>
+        <DokumentkravItem
+          dokumentkrav={mockDokumentkravList.krav[0]}
+          hasBundleError={false}
+          hasUnansweredError={false}
+          resetError={jest.fn()}
+        />
+      </MockContext>
+    );
+
+    await user.click(screen.getByLabelText(DOKUMENTKRAV_SVAR_SEND_NAA));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("dropzone")).toBeInTheDocument();
+    });
+  });
+
+  test("Should show additional input field begrunnelse if user chooses not to upload documentation", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MockContext dokumentkrav={mockDokumentkravList.krav}>
+        <DokumentkravItem
+          dokumentkrav={mockDokumentkravList.krav[0]}
+          hasBundleError={false}
+          hasUnansweredError={false}
+          resetError={jest.fn()}
+        />
+      </MockContext>
+    );
+
+    await user.click(screen.getByLabelText(DOKUMENTKRAV_SVAR_SENDER_IKKE));
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("faktum.dokument.dokumentkrav.svar.sender.ikke.begrunnelse")
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("Should post begrunnelse when user answers dokumentkrav begrunnelse", async () => {
+    fetch.mockResponses(
+      [JSON.stringify(mockDokumentkravList), { status: 200 }] // New dokumentkrav state from dp-soknad when user posts begrunnelse
+    );
+
+    const testDokumentkrav = {
+      ...mockDokumentkravList.krav[0],
+      svar: DOKUMENTKRAV_SVAR_SENDER_IKKE as GyldigDokumentkravSvar,
+      begrunnelse: undefined,
+    };
+
+    const user = userEvent.setup();
+
+    render(
+      <MockContext dokumentkrav={[testDokumentkrav]}>
+        <DokumentkravItem
+          dokumentkrav={testDokumentkrav}
+          hasBundleError={false}
+          hasUnansweredError={false}
+          resetError={jest.fn()}
+        />
+      </MockContext>
+    );
+
+    await user.type(
+      screen.getByLabelText("faktum.dokument.dokumentkrav.svar.sender.ikke.begrunnelse"),
+      "En begrunnelse her"
+    );
+
+    await waitFor(() => {
+      expect(fetch.mock.calls.length).toEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
Prøver meg på API-tester. Tok noen vanskelige routes først, både lagring av faktum og sletting av filer har flere requester videre før de sender tilbake et svar.

Det som er dumt med NextJS er at vi ikke kan ha testfiler inni `pages` mappa. Da vil det lages egne routes for disse, noe vi ikke ønsker. Har dermed opprettet en `__tests__` mappe, selv om vi egentlig har testene sammen med komponenten de tilhører.

Et steg videre her vil være å skjule all mocking av dp-auth i en egen fil, men jeg fikk det ikke til i farta. Det er uansett noe vi kan se på videre hvis vi ønsker å gå for flere slike tester.