### PR TITLE
Fjerner ubrukte envs for søknadsdialogen

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -48,7 +48,7 @@ spec:
     - name: DEKORATOR_ENV
       value: {{dekorator.env}}
     - name: VEILARBPROXY_URL
-      value: http://veilarbregistrering.paw.svc.cluster.local/veilarbregistrering/api/arbeidssoker/perioder
+      value: {{veilarbproxyUrl}}
   idporten:
     enabled: true
     sidecar:

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -52,7 +52,7 @@ spec:
     - name: LOGINSERVICE_WELL_KNOWN_URL
       value: {{loginservice.wellKnown}}
     - name: VEILARBPROXY_URL
-      value: {{veilarbproxyUrl}}
+      value: http://veilarbregistrering.paw.svc.cluster.local/veilarbregistrering/api/arbeidssoker/perioder
   idporten:
     enabled: true
     sidecar:

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -47,10 +47,6 @@ spec:
       value: {{dekorator.url}}
     - name: DEKORATOR_ENV
       value: {{dekorator.env}}
-    - name: LOGINSERVICE_URL
-      value: {{loginservice.url}}
-    - name: LOGINSERVICE_WELL_KNOWN_URL
-      value: {{loginservice.wellKnown}}
     - name: VEILARBPROXY_URL
       value: http://veilarbregistrering.paw.svc.cluster.local/veilarbregistrering/api/arbeidssoker/perioder
   idporten:

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -51,8 +51,6 @@ spec:
       value: {{loginservice.url}}
     - name: LOGINSERVICE_WELL_KNOWN_URL
       value: {{loginservice.wellKnown}}
-    - name: NEXT_PUBLIC_SENTRY_ENV
-      value: {{sentry_env}}
     - name: VEILARBPROXY_URL
       value: {{veilarbproxyUrl}}
   idporten:

--- a/.nais/vars-dev.yaml
+++ b/.nais/vars-dev.yaml
@@ -3,3 +3,4 @@ base_path: "/dagpenger/dialog"
 dekorator:
   url: https://dekoratoren.dev.nav.no/
   env: dev
+veilarbproxyUrl: http://veilarbregistrering.paw.svc.cluster.local/veilarbregistrering/api/arbeidssoker/perioder

--- a/.nais/vars-dev.yaml
+++ b/.nais/vars-dev.yaml
@@ -3,6 +3,3 @@ base_path: "/dagpenger/dialog"
 dekorator:
   url: https://dekoratoren.dev.nav.no/
   env: dev
-loginservice:
-  url: https://loginservice.dev.nav.no/login
-  wellKnown: https://navtestb2c.b2clogin.com/navtestb2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1

--- a/.nais/vars-dev.yaml
+++ b/.nais/vars-dev.yaml
@@ -6,5 +6,4 @@ dekorator:
 loginservice:
   url: https://loginservice.dev.nav.no/login
   wellKnown: https://navtestb2c.b2clogin.com/navtestb2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1
-sentry_env: development
 veilarbproxyUrl: http://veilarbregistrering.paw.svc.cluster.local/veilarbregistrering/api/arbeidssoker/perioder

--- a/.nais/vars-dev.yaml
+++ b/.nais/vars-dev.yaml
@@ -6,4 +6,3 @@ dekorator:
 loginservice:
   url: https://loginservice.dev.nav.no/login
   wellKnown: https://navtestb2c.b2clogin.com/navtestb2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1
-veilarbproxyUrl: http://veilarbregistrering.paw.svc.cluster.local/veilarbregistrering/api/arbeidssoker/perioder

--- a/.nais/vars-prod.yaml
+++ b/.nais/vars-prod.yaml
@@ -6,4 +6,3 @@ dekorator:
 loginservice:
   url: https://loginservice.nav.no/login
   wellKnown: https://navnob2c.b2clogin.com/navnob2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten
-veilarbproxyUrl: http://veilarbregistrering.paw.svc.cluster.local/veilarbregistrering/api/arbeidssoker/perioder

--- a/.nais/vars-prod.yaml
+++ b/.nais/vars-prod.yaml
@@ -3,3 +3,4 @@ base_path: "/dagpenger/dialog"
 dekorator:
   url: https://www.nav.no/dekoratoren
   env: prod
+veilarbproxyUrl: http://veilarbregistrering.paw.svc.cluster.local/veilarbregistrering/api/arbeidssoker/perioder

--- a/.nais/vars-prod.yaml
+++ b/.nais/vars-prod.yaml
@@ -3,6 +3,3 @@ base_path: "/dagpenger/dialog"
 dekorator:
   url: https://www.nav.no/dekoratoren
   env: prod
-loginservice:
-  url: https://loginservice.nav.no/login
-  wellKnown: https://navnob2c.b2clogin.com/navnob2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten

--- a/.nais/vars-prod.yaml
+++ b/.nais/vars-prod.yaml
@@ -6,5 +6,4 @@ dekorator:
 loginservice:
   url: https://loginservice.nav.no/login
   wellKnown: https://navnob2c.b2clogin.com/navnob2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten
-sentry_env: production
 veilarbproxyUrl: http://veilarbregistrering.paw.svc.cluster.local/veilarbregistrering/api/arbeidssoker/perioder

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -1,7 +1,9 @@
 import * as Sentry from "@sentry/nextjs";
 
-const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
-const SENTRY_ENV = process.env.NEXT_PUBLIC_SENTRY_ENV || "development";
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
+/* Sentry ENV can't be set per environment since this code is bundled in with the static resources uploaded to our CDN. 
+   The same static bundle is used both by dev and production */
+const SENTRY_ENV = "production";
 
 Sentry.init({
   dsn: SENTRY_DSN,

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -1,7 +1,9 @@
 import * as Sentry from "@sentry/nextjs";
 
-const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
-const SENTRY_ENV = process.env.NEXT_PUBLIC_SENTRY_ENV || "development";
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
+/* Sentry ENV can't be set per environment since this code is bundled in with the static resources uploaded to our CDN. 
+   The same static bundle is used both by dev and production */
+const SENTRY_ENV = "production";
 
 Sentry.init({
   dsn: SENTRY_DSN,


### PR DESCRIPTION
@androa nevnte at vi ikke lenger trenger å ha env-variabler for loginService, dette var noe dp-auth brukte før. Fjerner dermed disse.

I tillegg har vi ingen måte å sette env for Sentry på. Fjerner dermed logikken vår der og legger til en kommentar. Tl;dr er at sentry-configen blir bygget som en del av static-koden til NextJS (i prod-versjon) før alle deploys og så lastet opp til CDN-løsningen vi bruker. 