### PR TITLE
Kombinerer logging til Sentry med logging til Elastic

### DIFF
--- a/src/components/faktum/faktum-boolean/FaktumBoolean.test.tsx
+++ b/src/components/faktum/faktum-boolean/FaktumBoolean.test.tsx
@@ -4,7 +4,7 @@ import { booleanToTextId, FaktumBoolean, textIdToBoolean } from "./FaktumBoolean
 import { IQuizGeneratorFaktum, QuizFaktum } from "../../../types/quiz.types";
 import userEvent from "@testing-library/user-event";
 
-import * as SentryLogger from "../../../sentry.logger";
+import * as SentryLogger from "../../../error.logger";
 import { MockContext } from "../../../__mocks__/MockContext";
 import { mockSaveFaktumToQuiz } from "../../../__mocks__/MockQuizProvider";
 

--- a/src/context/sanity-context.tsx
+++ b/src/context/sanity-context.tsx
@@ -9,7 +9,7 @@ import {
   ISanitySvaralternativ,
   ISanityTexts,
 } from "../types/sanity.types";
-import * as SentryLogger from "../sentry.logger";
+import * as SentryLogger from "../error.logger";
 
 export const SanityContext = React.createContext<ISanityTexts | undefined>(undefined);
 

--- a/src/error.logger.ts
+++ b/src/error.logger.ts
@@ -1,3 +1,4 @@
+import { logger } from "@navikt/next-logger";
 import * as Sentry from "@sentry/nextjs";
 
 export function logMissingSanityText(textId: string) {
@@ -5,11 +6,14 @@ export function logMissingSanityText(textId: string) {
 }
 
 export function logRequestError(error: string, uuid?: string) {
+  const uuidWithFallback = uuid ?? "Not provided";
   Sentry.captureException(new RequestError(`${error}`), {
     tags: {
-      uuid: uuid ?? "Not provided",
+      uuid: uuidWithFallback,
     },
   });
+
+  logger.error(`RequestError: ${error}, uuid: ${uuidWithFallback}`);
 }
 
 class MissingTextError extends Error {

--- a/src/hooks/useFetchRequest.ts
+++ b/src/hooks/useFetchRequest.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import * as Sentry from "@sentry/nextjs";
-import { RequestError } from "../sentry.logger";
+import { RequestError } from "../error.logger";
 
 export interface IErrorDetails {
   message: string;

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { sanityClient } from "../../sanity-client";
 import { ErrorPageContent } from "../components/error-page-content/errorPageContent";
 import { allTextsQuery } from "../sanity/groq-queries";
-import * as SentryLogger from "../sentry.logger";
+import * as SentryLogger from "../error.logger";
 import { ISanityTexts } from "../types/sanity.types";
 
 const fallbackErrorText = {

--- a/src/pages/api/documentation/[uuid]/[dokumentkravId]/file/save.ts
+++ b/src/pages/api/documentation/[uuid]/[dokumentkravId]/file/save.ts
@@ -7,7 +7,7 @@ import {
   getErrorMessage,
 } from "../../../../../../api.utils";
 import { getSession } from "../../../../../../auth.utils";
-import { logRequestError } from "../../../../../../sentry.logger";
+import { logRequestError } from "../../../../../../error.logger";
 import { IDokumentkravFil } from "../../../../../../types/documentation.types";
 import { headersWithToken } from "../../../../../../api/quiz-api";
 import Metrics from "../../../../../../metrics";

--- a/src/pages/api/documentation/[uuid]/index.ts
+++ b/src/pages/api/documentation/[uuid]/index.ts
@@ -4,7 +4,7 @@ import { audienceDPSoknad, getErrorMessage } from "../../../../api.utils";
 import { withSentry } from "@sentry/nextjs";
 import { headersWithToken } from "../../../../api/quiz-api";
 import { getSession } from "../../../../auth.utils";
-import { logRequestError } from "../../../../sentry.logger";
+import { logRequestError } from "../../../../error.logger";
 
 export function getDokumentkrav(uuid: string, onBehalfOfToken: string) {
   return fetch(`${process.env.API_BASE_URL}/soknad/${uuid}/dokumentasjonskrav`, {

--- a/src/pages/api/documentation/bundle.ts
+++ b/src/pages/api/documentation/bundle.ts
@@ -8,7 +8,7 @@ import {
   getErrorMessage,
 } from "../../../api.utils";
 import { getSession } from "../../../auth.utils";
-import { logRequestError } from "../../../sentry.logger";
+import { logRequestError } from "../../../error.logger";
 import { headersWithToken } from "../../../api/quiz-api";
 import Metrics from "../../../metrics";
 

--- a/src/pages/api/documentation/download/[...params].ts
+++ b/src/pages/api/documentation/download/[...params].ts
@@ -4,7 +4,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { withSentry } from "@sentry/nextjs";
 import { audienceMellomlagring, getErrorMessage } from "../../../../api.utils";
 import { getSession } from "../../../../auth.utils";
-import { logRequestError } from "../../../../sentry.logger";
+import { logRequestError } from "../../../../error.logger";
 
 const filePath = path.resolve("src/localhost-data/sample.pdf");
 const imageBuffer = fs.readFileSync(filePath);

--- a/src/pages/api/documentation/file/delete.ts
+++ b/src/pages/api/documentation/file/delete.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { withSentry } from "@sentry/nextjs";
 import { getSession } from "../../../../auth.utils";
-import { logRequestError } from "../../../../sentry.logger";
+import { logRequestError } from "../../../../error.logger";
 import { headersWithToken } from "../../../../api/quiz-api";
 import { audienceDPSoknad, audienceMellomlagring, getErrorMessage } from "../../../../api.utils";
 

--- a/src/pages/api/documentation/svar.ts
+++ b/src/pages/api/documentation/svar.ts
@@ -3,7 +3,7 @@ import { withSentry } from "@sentry/nextjs";
 import { getSession } from "../../../auth.utils";
 import { audienceDPSoknad, getErrorMessage } from "../../../api.utils";
 import { headersWithToken } from "../../../api/quiz-api";
-import { logRequestError } from "../../../sentry.logger";
+import { logRequestError } from "../../../error.logger";
 import { GyldigDokumentkravSvar } from "../../../types/documentation.types";
 import { getDokumentkrav } from "./[uuid]";
 

--- a/src/pages/api/personalia/index.ts
+++ b/src/pages/api/personalia/index.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { audienceDPSoknad, getErrorMessage } from "../../../api.utils";
 import { withSentry } from "@sentry/nextjs";
 import { getSession } from "../../../auth.utils";
-import { logRequestError } from "../../../sentry.logger";
+import { logRequestError } from "../../../error.logger";
 
 export function getPersonalia(onBehalfOfToken: string) {
   const url = `${process.env.API_BASE_URL}/personalia`;

--- a/src/pages/api/soknad/delete.ts
+++ b/src/pages/api/soknad/delete.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { audienceDPSoknad, getErrorMessage } from "../../../api.utils";
 import { headersWithToken } from "../../../api/quiz-api";
 import { getSession } from "../../../auth.utils";
-import { logRequestError } from "../../../sentry.logger";
+import { logRequestError } from "../../../error.logger";
 
 export interface IDeleteSoknadBody {
   uuid: string;

--- a/src/pages/api/soknad/ettersend.ts
+++ b/src/pages/api/soknad/ettersend.ts
@@ -2,7 +2,7 @@ import { withSentry } from "@sentry/nextjs";
 import { NextApiRequest, NextApiResponse } from "next";
 import { audienceDPSoknad, getErrorMessage } from "../../../api.utils";
 import { getSession } from "../../../auth.utils";
-import { logRequestError } from "../../../sentry.logger";
+import { logRequestError } from "../../../error.logger";
 import { headersWithToken } from "../../../api/quiz-api";
 
 export interface IEttersendBody {

--- a/src/pages/api/soknad/ferdigstill.ts
+++ b/src/pages/api/soknad/ferdigstill.ts
@@ -5,7 +5,7 @@ import { audienceDPSoknad, getErrorMessage } from "../../../api.utils";
 import { getSession } from "../../../auth.utils";
 import { allTextsQuery } from "../../../sanity/groq-queries";
 import { textStructureToHtml } from "../../../sanity/textStructureToHtml";
-import { logRequestError } from "../../../sentry.logger";
+import { logRequestError } from "../../../error.logger";
 import { ISanityTexts } from "../../../types/sanity.types";
 import { headersWithToken } from "../../../api/quiz-api";
 import { type Locale } from "@navikt/nav-dekoratoren-moduler/ssr";

--- a/src/pages/api/soknad/uuid.ts
+++ b/src/pages/api/soknad/uuid.ts
@@ -3,7 +3,7 @@ import { audienceDPSoknad, getErrorMessage } from "../../../api.utils";
 import { createSoknadUuid } from "../../../api/quiz-api";
 import { withSentry } from "@sentry/nextjs";
 import { getSession } from "../../../auth.utils";
-import { logRequestError } from "../../../sentry.logger";
+import { logRequestError } from "../../../error.logger";
 
 async function uuidHandler(req: NextApiRequest, res: NextApiResponse) {
   if (process.env.NEXT_PUBLIC_LOCALHOST) {


### PR DESCRIPTION
Fra før av logger vi mye til Sentry fra de forskjellige API-endepunktene våre. Jeg kombinerer det som før kun var Sentry til å også logge til Elastic. Burde de to måtene å logge på være mer separat enn det jeg gjør de til nå, eller ser dette greit ut?