### PR TITLE
Oppdaterer accessPolicy med eksterne URLer vi går mot

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -65,12 +65,13 @@ spec:
   accessPolicy:
     outbound:
       external:
-        - host: dev.dekoratoren.nav.no
         - host: api.sanity.io
         - host: apicdn.sanity.io
         - host: cdn.sanity.io
         - host: rt6o382n.api.sanity.io
         - host: rt6o382n.apicdn.sanity.io
+        - host: www.nav.no
+        - host: dekoratoren.dev.nav.no
       rules:
         - application: dp-soknad
         - application: dp-mellomlagring

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -65,9 +65,6 @@ spec:
   accessPolicy:
     outbound:
       external:
-        - host: api.sanity.io
-        - host: apicdn.sanity.io
-        - host: cdn.sanity.io
         - host: rt6o382n.api.sanity.io
         - host: rt6o382n.apicdn.sanity.io
         - host: www.nav.no

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -65,7 +65,6 @@ spec:
   accessPolicy:
     outbound:
       external:
-        - host: rt6o382n.api.sanity.io
         - host: rt6o382n.apicdn.sanity.io
         - host: www.nav.no
         - host: dekoratoren.dev.nav.no

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -73,7 +73,7 @@ spec:
         - host: www.nav.no
         - host: dekoratoren.dev.nav.no
         - host: amplitude.nav.no
-        - host: 1d4d9592b0c4442889ba64e028a16c09@sentry.gc.nav.no
+        - host: sentry.gc.nav.no
       rules:
         - application: dp-soknad
         - application: dp-mellomlagring

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -72,6 +72,7 @@ spec:
         - host: rt6o382n.apicdn.sanity.io
         - host: www.nav.no
         - host: dekoratoren.dev.nav.no
+        - host: amplitude.nav.no
       rules:
         - application: dp-soknad
         - application: dp-mellomlagring

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -66,6 +66,11 @@ spec:
     outbound:
       external:
         - host: dev.dekoratoren.nav.no
+        - host: api.sanity.io
+        - host: apicdn.sanity.io
+        - host: cdn.sanity.io
+        - host: rt6o382n.api.sanity.io
+        - host: rt6o382n.apicdn.sanity.io
       rules:
         - application: dp-soknad
         - application: dp-mellomlagring

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -73,6 +73,7 @@ spec:
         - host: www.nav.no
         - host: dekoratoren.dev.nav.no
         - host: amplitude.nav.no
+        - host: 1d4d9592b0c4442889ba64e028a16c09@sentry.gc.nav.no
       rules:
         - application: dp-soknad
         - application: dp-mellomlagring


### PR DESCRIPTION
Har lagt til:
- Sanity
- Sentry (usikker på om det heller skal være `sentry.gc.nav.no`, gikk for den superspesifikke urlen enn så lenge)
- Amplitude (via NAV sin amplitude-proxy)
- NAV-Dekoratøren (jeg antar at denne burde være med?)

Dette er noe gjetting på hvilke URLer vi trenger, basert på søking på navikt-spacet på github hvordan andre har satt det opp. Sanity er jeg ganske sikker på er riktig, siden veldig mange andre også har med alle URLene i sin config. Sentry er jeg minst sikker på, det er vill gjetning fra min side at det er riktig url. Det er vanskelig å teste siden dette kun får konsekvenser for BFFen, og at vi kun får opp logginnslag etter minimum 24 timer. Dev og prod-logger er også kombinert, så vanskelig å se hvilke som er hvilke.