### PR TITLE
lagt til guard for kun whitespace i streng

### DIFF
--- a/src/components/faktum/faktum-text/FaktumText.tsx
+++ b/src/components/faktum/faktum-text/FaktumText.tsx
@@ -34,6 +34,12 @@ export function FaktumTextComponent(
 
   useEffect(() => {
     if (!isFirstRender && debouncedText !== faktum.svar) {
+      //backend does not allow a string containing only whitespace, giving us a bad request so do not try to save answer
+      //trim is used to check if the string contains only whitespace. if only whitespace, do nothing.
+      //still need to let the algorithm continue if length is 0 because that indicates to us that we need to null the answer
+      if (debouncedText.length > 0 && !debouncedText.trim()) {
+        return;
+      }
       const inputValue = debouncedText.length === 0 ? null : debouncedText;
       saveFaktum(inputValue);
     }


### PR DESCRIPTION
Backend sin innebygde funksjon for å sjekke at en streng ikke er tom, inkluderer at den passer på at strengen ikke inneholder kun whitespace. Legger derfor på en guard i tekstinputs for å forhindre at vi prøver å lagre når strengen består av kun whitespace (og dermed gir bad request, som igjen gir en veldig generisk "noe gikk galt" feilmelding midt i søknadsprosessen hvis en person skriver litt sakte og tilfeldigvis trykket på spacebar i et tomt tekstinputfelt.

kudos til rebecca for å oppdage feilen

lenke til hvordan trim funksjonen funker
https://www.w3schools.com/jsref/jsref_trim_string.asp