### PR TITLE
WIP: Legger på veiledningen i forkant på søknaden på pdf-brutto

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -48,3 +48,9 @@
   margin-top: var(--a-spacing-9);
   gap: var(--a-spacing-6);
 }
+
+.pdf-separator {
+  padding-bottom: var(--a-spacing-12);
+  margin-bottom: var(--a-spacing-12);
+  border-bottom: 3px solid var(--a-gray-400);
+}

--- a/src/pages/soknad/[uuid]/pdf-brutto.tsx
+++ b/src/pages/soknad/[uuid]/pdf-brutto.tsx
@@ -15,6 +15,7 @@ import { getPersonalia } from "../../api/personalia";
 import { IDokumentkravList } from "../../../types/documentation.types";
 import { getDokumentkrav } from "../../api/documentation/[uuid]";
 import { mockDokumentkravBesvart } from "../../../localhost-data/mock-dokumentkrav-besvart";
+import { StartSoknad } from "../../../views/start-soknad/StartSoknad";
 
 interface IProps {
   soknadState: IQuizState | null;
@@ -100,11 +101,11 @@ export default function PdfBruttoPage(props: IProps) {
   return (
     <QuizProvider initialState={props.soknadState}>
       <ValidationProvider>
-        <Pdf
-          personalia={props.personalia}
-          dokumentkravList={props.dokumentkrav}
-          pdfView={"brutto"}
-        />
+        <Pdf personalia={props.personalia} dokumentkravList={props.dokumentkrav} pdfView={"brutto"}>
+          <div className="pdf-separator">
+            <StartSoknad preview={true} />
+          </div>
+        </Pdf>
       </ValidationProvider>
     </QuizProvider>
   );

--- a/src/views/pdf/Pdf.tsx
+++ b/src/views/pdf/Pdf.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { PropsWithChildren } from "react";
 import { PageMeta } from "../../components/PageMeta";
 import { SoknadHeader } from "../../components/soknad-header/SoknadHeader";
 import { Section } from "../../components/section/Section";
@@ -8,7 +8,7 @@ import { Personalia } from "../../components/personalia/Personalia";
 import { IPersonalia } from "../../types/personalia.types";
 import { IDokumentkrav, IDokumentkravList } from "../../types/documentation.types";
 import { ReceiptDokumentkravUploadedItem } from "../../components/receipt-dokumentkrav/ReceiptDokumentkravUploadedItem";
-import { Heading } from "@navikt/ds-react";
+import { Alert, Heading } from "@navikt/ds-react";
 import styles from "./Pdf.module.css";
 import { ReceiptDokumentkravMissingItem } from "../../components/receipt-dokumentkrav/ReceiptDokumentkravMissingItem";
 import { ReceiptDocumentsNotSendingItem } from "../../components/receipt-documents-not-sending/ReceiptDocumentsNotSendingItem";
@@ -26,7 +26,7 @@ interface IProps {
 
 export type PdfView = "netto" | "brutto";
 
-export function Pdf(props: IProps) {
+export function Pdf(props: PropsWithChildren<IProps>) {
   const { personalia, dokumentkravList, pdfView } = props;
   const { getAppText } = useSanity();
   const { soknadState } = useQuiz();
@@ -43,6 +43,8 @@ export function Pdf(props: IProps) {
       />
       <SoknadHeader />
       <main>
+        {props.children}
+
         <Personalia personalia={personalia} />
 
         {soknadState.seksjoner.map((section) => (
@@ -60,6 +62,8 @@ export function Pdf(props: IProps) {
           <Heading spacing size="large" level="2">
             Dokumentkrav
           </Heading>
+
+          {dokumentkravList.krav.length === 0 && <Alert variant="info">Ingen dokumentkrav</Alert>}
 
           <ol className={styles.dokumentkravList}>
             {missingDocuments.map((dokumentkrav) => (

--- a/src/views/start-soknad/StartSoknad.tsx
+++ b/src/views/start-soknad/StartSoknad.tsx
@@ -15,7 +15,11 @@ import { ErrorTypesEnum } from "../../types/error.types";
 import { trackSkjemaStartet } from "../../amplitude.tracking";
 import { logger } from "@navikt/next-logger";
 
-export function StartSoknad() {
+interface IProps {
+  preview?: boolean;
+}
+
+export function StartSoknad({ preview = false }: IProps) {
   const router = useRouter();
   const { setFocus } = useSetFocus();
   const [isError, setIsError] = useState(false);
@@ -31,6 +35,12 @@ export function StartSoknad() {
       setFocus(missingConsentRef);
     }
   }, [showConsentValidation]);
+
+  useEffect(() => {
+    if (preview) {
+      setConsentGiven(true);
+    }
+  }, []);
 
   async function startSoknad() {
     if (!consentGiven) {
@@ -72,7 +82,9 @@ export function StartSoknad() {
         title={getAppText("arbeidssokerstatus.side-metadata.tittel")}
         description={getAppText("arbeidssokerstatus.side-metadata.meta-beskrivelse")}
       />
-      <SoknadHeader />
+
+      {!preview && <SoknadHeader />}
+
       <main>
         {startSideText?.body && (
           <PortableText

--- a/src/views/start-soknad/StartSoknad.tsx
+++ b/src/views/start-soknad/StartSoknad.tsx
@@ -24,7 +24,7 @@ export function StartSoknad({ preview = false }: IProps) {
   const { setFocus } = useSetFocus();
   const [isError, setIsError] = useState(false);
   const { getAppText, getInfosideText } = useSanity();
-  const [consentGiven, setConsentGiven] = useState<boolean>(false);
+  const [consentGiven, setConsentGiven] = useState<boolean>(preview);
   const [isCreatingSoknadUUID, setIsCreatingSoknadUUID] = useState(false);
   const [showConsentValidation, setShowConsentValidation] = useState(false);
   const missingConsentRef = useRef<HTMLInputElement>(null);
@@ -35,12 +35,6 @@ export function StartSoknad({ preview = false }: IProps) {
       setFocus(missingConsentRef);
     }
   }, [showConsentValidation]);
-
-  useEffect(() => {
-    if (preview) {
-      setConsentGiven(true);
-    }
-  }, []);
 
   async function startSoknad() {
     if (!consentGiven) {


### PR DESCRIPTION
Vi skal bruke frontend sin HTML for å generere backend sin PDF. Da vil vi også se hvilken veiledning brukeren har fått i forkant av søknaden som er sendt. Legger den dermed ved pdf-brutto, på toppen av siden. Pdf-netto skal være kun søknadssvarene, som før.