### PR TITLE
Fjern merkelapp for status på søknaden

### DIFF
--- a/src/components/receipt-soknad-status/ReceiptSoknadStatus.tsx
+++ b/src/components/receipt-soknad-status/ReceiptSoknadStatus.tsx
@@ -1,4 +1,4 @@
-import { Detail, Heading, Tag } from "@navikt/ds-react";
+import { Detail, Heading } from "@navikt/ds-react";
 import { PortableText } from "@portabletext/react";
 import { useSanity } from "../../context/sanity-context";
 import { ISoknadStatus, ISoknadStatuser } from "../../types/quiz.types";
@@ -17,18 +17,13 @@ export function ReceiptSoknadStatus(props: ISoknadStatus) {
             ? getAppText("kvittering.soknad-status.title.ferdig")
             : getAppText("kvittering.soknad-status.title.mottatt")}
         </Heading>
-        {props.status !== "Ukjent" && (
-          <Tag variant={getTagColor(props.status)}>
-            {getAppText(getStatusTagTextKey(props.status))}
-          </Tag>
-        )}
       </div>
 
       {props.innsendt && (
         <Detail>
           {`${getAppText("kvittering.soknad-status.subtitle.innsendt-dato")} ${format(
             new Date(props.innsendt),
-            "dd.MM.yyyy - HH:mm"
+            "dd.MM.yyyy - HH:mm",
           )}`}
         </Detail>
       )}
@@ -50,31 +45,5 @@ function getStatusDescriptionTextKey(status: ISoknadStatuser) {
       return "kvittering.soknad-status.description.ukjent";
     default:
       return "getStatusDescriptionTextKey() no-text-key";
-  }
-}
-
-function getStatusTagTextKey(status: ISoknadStatuser) {
-  switch (status) {
-    case "UnderBehandling":
-      return "kvittering.soknad-status.tag.under-behandling";
-    case "FerdigBehandlet":
-      return "kvittering.soknad-status.tag.ferdig-behehandlet";
-    case "ManglerDokumenter":
-      return "kvittering.soknad-status.tag.mangler-dokumenter";
-    default:
-      return "getStatusTagTextKey() no-text-key";
-  }
-}
-
-function getTagColor(status: ISoknadStatuser) {
-  switch (status) {
-    case "UnderBehandling":
-      return "info";
-    case "FerdigBehandlet":
-      return "success";
-    case "ManglerDokumenter":
-      return "warning";
-    default:
-      return "info";
   }
 }


### PR DESCRIPTION
Denne fungerer ikke med den nye saksbehandlingsløsningen, så da er det bedre å fjerne den enn å vise noe feil.
Vi vurderte å fortsatt vise "mangler dokumentasjon", men det er enklere å fjerne alt nå, og ev. legge på noe ekstra for å fortelle bruker at de må gjøre noe mer.